### PR TITLE
Apply zero opinion layer for new users

### DIFF
--- a/psql-connector/Cargo.toml
+++ b/psql-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmer2"
-version = "0.3.23"
+version = "0.3.24"
 edition = "2021"
 
 [[bin]]

--- a/psql-connector/src/lib.rs
+++ b/psql-connector/src/lib.rs
@@ -1,4 +1,4 @@
-use core::result::Result;
+se core::result::Result;
 use lazy_static::lazy_static;
 use meritrank_service::protocol::*;
 use nng::options::{Options, RecvTimeout};
@@ -135,8 +135,8 @@ fn mr_node_score(
       name!(dst, String),
       name!(score_value_of_dst, f64),
       name!(score_value_of_src, f64),
-      name!(score_cluster_of_dst, f64),
-      name!(score_cluster_of_src, f64),
+      name!(score_cluster_of_dst, i32),
+      name!(score_cluster_of_src, i32),
     ),
   >,
   Box<dyn Error + 'static>,
@@ -154,7 +154,7 @@ fn mr_node_score(
     payload:  args,
   })?;
 
-  let response: Vec<(String, String, f64, f64, f64, f64)> =
+  let response: Vec<(String, String, f64, f64, i32, i32)> =
     request(payload, Some(*RECV_TIMEOUT_MSEC))?;
   Ok(TableIterator::new(response))
 }
@@ -226,8 +226,8 @@ fn mr_scores(
       name!(dst, String),
       name!(score_value_of_dst, f64),
       name!(score_value_of_src, f64),
-      name!(score_cluster_of_dst, f64),
-      name!(score_cluster_of_src, f64),
+      name!(score_cluster_of_dst, i32),
+      name!(score_cluster_of_src, i32),
     ),
   >,
   Box<dyn Error + 'static>,
@@ -245,7 +245,7 @@ fn mr_scores(
     count,
   )?;
 
-  let response: Vec<(String, String, f64, f64, f64, f64)> =
+  let response: Vec<(String, String, f64, f64, i32, i32)> =
     request(payload, Some(*RECV_TIMEOUT_MSEC))?;
   Ok(TableIterator::new(response))
 }
@@ -267,8 +267,8 @@ fn mr_graph(
       name!(weight, f64),
       name!(score_value_of_dst, f64),
       name!(score_value_of_ego, f64),
-      name!(score_cluster_of_dst, f64),
-      name!(score_cluster_of_ego, f64),
+      name!(score_cluster_of_dst, i32),
+      name!(score_cluster_of_ego, i32),
     ),
   >,
   Box<dyn Error + 'static>,
@@ -289,7 +289,7 @@ fn mr_graph(
     payload:  args,
   })?;
 
-  let response: Vec<(String, String, f64, f64, f64, f64, f64)> =
+  let response: Vec<(String, String, f64, f64, f64, i32, i32)> =
     request(payload, Some(*RECV_TIMEOUT_MSEC))?;
   Ok(TableIterator::new(response))
 }
@@ -375,8 +375,8 @@ fn mr_mutual_scores(
       name!(dst, String),
       name!(score_value_of_dst, f64),
       name!(score_value_of_src, f64),
-      name!(score_cluster_of_dst, f64),
-      name!(score_cluster_of_src, f64),
+      name!(score_cluster_of_dst, i32),
+      name!(score_cluster_of_src, i32),
     ),
   >,
   Box<dyn Error + 'static>,
@@ -393,7 +393,7 @@ fn mr_mutual_scores(
     payload:  args,
   })?;
 
-  let response: Vec<(String, String, f64, f64, f64, f64)> =
+  let response: Vec<(String, String, f64, f64, i32, i32)> =
     request(payload, Some(*RECV_TIMEOUT_MSEC))?;
   Ok(TableIterator::new(response))
 }
@@ -595,8 +595,8 @@ fn mr_fetch_new_edges(
       name!(dst, String),
       name!(score_value_of_dst, f64),
       name!(score_value_of_src, f64),
-      name!(score_cluster_of_dst, f64),
-      name!(score_cluster_of_src, f64),
+      name!(score_cluster_of_dst, i32),
+      name!(score_cluster_of_src, i32),
     ),
   >,
   Box<dyn Error + 'static>,
@@ -613,9 +613,9 @@ fn mr_fetch_new_edges(
     payload:  args,
   })?;
 
-  let response: Vec<(String, f64, f64, f64, f64)> =
+  let response: Vec<(String, f64, f64, i32, i32)> =
     request(payload, Some(*RECV_TIMEOUT_MSEC))?;
-  let edges: Vec<(String, String, f64, f64, f64, f64)> = response
+  let edges: Vec<(String, String, f64, f64, i32, i32)> = response
     .iter()
     .map(
       |(

--- a/psql-connector/src/lib.rs
+++ b/psql-connector/src/lib.rs
@@ -1,4 +1,4 @@
-se core::result::Result;
+use core::result::Result;
 use lazy_static::lazy_static;
 use meritrank_service::protocol::*;
 use nng::options::{Options, RecvTimeout};

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meritrank_service"
-version = "0.2.31"
+version = "0.2.32"
 edition = "2021"
 
 [features]

--- a/service/src/operations.rs
+++ b/service/src/operations.rs
@@ -744,8 +744,7 @@ impl AugMultiGraph {
     log_trace!("fetch_raw_score");
 
     if self.cache_walk_get(context, ego_id) {
-      let graph = self.graph_from(context);
-      match graph.get_node_score(ego_id, dst_id) {
+      match self.graph_from(context).get_node_score(ego_id, dst_id) {
         Ok(score) => {
           self.cache_score_add(context, ego_id, dst_id, score);
           self.with_zero_opinion(context, dst_id, score)
@@ -2139,7 +2138,7 @@ impl AugMultiGraph {
 //  ================================================
 
 impl AugMultiGraph {
-  fn reduced_graph(&mut self) -> Vec<(NodeId, NodeId, Weight)> {
+  pub fn reduced_graph(&mut self) -> Vec<(NodeId, NodeId, Weight)> {
     log_trace!("reduced_graph");
 
     let users: Vec<NodeId> = self
@@ -2198,7 +2197,7 @@ impl AugMultiGraph {
     result
   }
 
-  fn top_nodes(&mut self) -> Vec<(NodeId, f64)> {
+  pub fn top_nodes(&mut self) -> Vec<(NodeId, f64)> {
     log_trace!("top_nodes");
 
     let reduced = self.reduced_graph();
@@ -2241,7 +2240,11 @@ impl AugMultiGraph {
 
     self.recalculate_all(0);
     let nodes = self.top_nodes();
+
+    //  Drop all walks and make sure to empty caches.
     self.recalculate_all(0);
+    self.cached_scores = vec![];
+    self.cached_walks = vec![];
 
     self.zero_opinion.resize(0, 0.0);
     self.zero_opinion.reserve(nodes.len());

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -955,7 +955,9 @@ fn graph_sort_order() {
   graph.write_recalculate_zero();
 
   let res: Vec<_> =
-    graph.read_graph("", "Uadeb43da4abb", "U000000000000", false, 0, 10000);
+    graph.read_graph("", "Uadeb43da4abb", "Bfae1726e4e87", false, 0, 10000);
+
+  assert!(res.len() > 1);
 
   for n in 1..res.len() {
     assert!(res[n - 1].2.abs() >= res[n].2.abs());
@@ -971,7 +973,9 @@ fn recalculate_zero_graph_duplicates() {
   graph.write_recalculate_zero();
 
   let res: Vec<_> =
-    graph.read_graph("", "U000000000000", "Ub01f4ad1b03f", false, 0, 10000);
+    graph.read_graph("", "Bb5f87c1621d5", "Ub01f4ad1b03f", false, 0, 10000);
+
+  assert!(res.len() > 1);
 
   for (i, x) in res.iter().enumerate() {
     for (j, y) in res.iter().take(i).enumerate() {
@@ -1041,7 +1045,9 @@ fn recalculate_zero_reset_perf() {
   let get_time =
     || SystemTime::now().duration_since(begin).unwrap().as_millis();
 
-  graph.read_graph("", "Uadeb43da4abb", "U000000000000", true, 0, 10000);
+  let res: Vec<_> = graph.read_graph("", "Uadeb43da4abb", "B0e230e9108dd", true, 0, 10000);
+
+  assert!(res.len() > 1);
 
   assert!(get_time() < 200);
 }

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -1101,9 +1101,367 @@ fn scores_sort_order() {
     u32::MAX,
   );
 
+  assert!(res.len() > 1);
+
   for n in 1..res.len() {
     assert!(res[n - 1].2.abs() >= res[n].2.abs());
   }
+}
+
+fn put_testing_edges_with_zero(graph : &mut AugMultiGraph) {
+  graph.write_put_edge("", "U784662a9d229", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ub660dcc736b6", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ub4b17bc06434", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0ae9f5d0bf02", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ue62e5ffad707", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0929c858681e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uf82dbb4708ba", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ucf8af4b3fa12", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0be96c3b9883", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ub4b46ee7a5e4", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U1691db0d4d7f", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U70303578cf3d", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U7725640de5b2", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U00a73eafb789", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ucc76e1b73be0", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U133f8c421ed0", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U043fbd8f99fa", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U13f1bde6e566", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U5d33a9be1633", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U17b825d673df", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0d2e9e0dc40e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U3ea0a229ad85", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U68c2a35a5c73", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ub9713d01f478", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0ea4876f2b2b", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U6f2df9691c1e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U49f87748a6eb", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ua3974669b55c", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U7f00a4668300", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud3fedd6e69de", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uf5dc346ce127", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ue925856b9cd9", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U323855718209", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U71deb40da828", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ufc33a8cb3e4d", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ub47d8c364c9e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U163b54808a6b", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ub38adbd60723", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Udf36e098c231", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U58c3e7370e32", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U95c43e314793", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uf765bb63af01", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U75cddb09a54e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U01558602b2d5", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U86e3be9101fa", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0bf7eddae79d", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U2db9f2283f6a", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uef1c0af37d4c", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U4506d6073350", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U777590fcd586", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ua18956bd9c25", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U55272fd6c264", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U69218e678fdc", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U29a00cc1c9c2", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U3be62375581d", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U19ad3b903835", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Udecbe941f450", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U948afb314973", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U8af8a7e48e6d", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U57c0388e5cb5", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ub28987fd8681", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U66bb6232f9fc", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uc12f2b363b9c", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U77a03e9a08af", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud10b3f42f87b", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U9de057150efc", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U881eb59c559f", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U3a466eaf5798", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U422adbe0083e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0080a5f2547d", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud21004c2382a", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uadeb43da4abb", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U861750348e9f", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uc4ebbce44401", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ue55b928fa8dd", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ue87b661973ef", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U3da01fd48941", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U58d7f150b0f9", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ua5cf9177c96e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U04d86c56e1b8", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U7b30e21179fc", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U47746fcce8c0", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ue6cc7bfa0efd", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U9a89e0679dec", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Udb60bbb285ca", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U9e42f6dab85a", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uc3c31b8a022f", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U26aca0e369c7", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0d47e4861ef0", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U99a0f1f7e6ee", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U21769235b28d", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U390d75770ac1", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U6d23bed38776", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ued8da07b9559", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U76a293d70033", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U40bb83163d40", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U34252014c05b", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ua37f245cf686", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud7002ae5a86c", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ucc6cc40df2b7", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U46e5959770ad", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U614185021ae5", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ueb139752b907", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U6661263fb410", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U02fbd7c8df4c", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud5b22ebf52f2", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U41784ed376c3", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U9605bd4d1218", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ub93799d9400e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U682c3380036f", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U6240251593cd", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U697c59e5d3d7", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ua12e78308f49", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U9e972ae23870", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud2123c013577", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ub7b49e360599", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud9df8116deba", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uce7e9acd408e", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ube0563a943d9", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uda18fb0fbcee", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Udcc4d659895b", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U1e41b5f3adff", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud04c89aaf453", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U79466f73dc0c", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Uc35c445325f5", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U3c63a9b6115a", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0cd6bd2dde4f", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud5df48b5768c", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ua3e5f30e88c2", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U2cd96f1b2ea6", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud3d487baa4db", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U84ba0b3e06d4", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U638f5c19326f", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U11456af7d414", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U67bf00435429", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U5e745dde0c76", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ue40b938f47a4", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U6307b2993c24", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ud1fb013acf2c", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U425e5e1ff39b", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ucc8ea98c2b41", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U3c963c53d335", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ua06b740988b1", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ucb442106b78c", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U0da9b1b0859f", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U95f3426b8e5d", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "Ue9e793f3ad14", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U95f3426b8e5d", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U77a03e9a08af", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Ub47d8c364c9e", "Ub01f4ad1b03f", 1.0, -1);
+  graph.write_put_edge("", "U0be96c3b9883", "U5d33a9be1633", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "U9a89e0679dec", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "U0c17798eaab4", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "Udece0afd9a8b", -1.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "U1c285703fc63", 1.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "Uadeb43da4abb", -1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Uc3c31b8a022f", -1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "Udece0afd9a8b", 1.0, -1);
+  graph.write_put_edge("", "U5d33a9be1633", "U0be96c3b9883", 1.0, -1);
+  graph.write_put_edge("", "U0be96c3b9883", "U55272fd6c264", 1.0, -1);
+  graph.write_put_edge("", "U7725640de5b2", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U323855718209", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U7725640de5b2", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "U7725640de5b2", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U3ea0a229ad85", "U55272fd6c264", 1.0, -1);
+  graph.write_put_edge("", "U3ea0a229ad85", "U0be96c3b9883", 1.0, -1);
+  graph.write_put_edge("", "U3ea0a229ad85", "Ub01f4ad1b03f", 1.0, -1);
+  graph.write_put_edge("", "U425e5e1ff39b", "U76a293d70033", 1.0, -1);
+  graph.write_put_edge("", "Ucf8af4b3fa12", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U1691db0d4d7f", "U3ea0a229ad85", 1.0, -1);
+  graph.write_put_edge("", "U3ea0a229ad85", "U1691db0d4d7f", 1.0, -1);
+  graph.write_put_edge("", "U76a293d70033", "U425e5e1ff39b", 1.0, -1);
+  graph.write_put_edge("", "Ub9713d01f478", "Ud10b3f42f87b", 1.0, -1);
+  graph.write_put_edge("", "Ucc6cc40df2b7", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U0da9b1b0859f", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U0da9b1b0859f", "U55272fd6c264", 1.0, -1);
+  graph.write_put_edge("", "U6307b2993c24", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Ue925856b9cd9", "Ub4b17bc06434", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "Uad577360d968", 1.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "Uc3c31b8a022f", -1.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "U9e42f6dab85a", -1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Uaa4e2be7a87a", -1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "U1c285703fc63", -1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "U1c285703fc63", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "U02fbd7c8df4c", 1.0, -1);
+  graph.write_put_edge("", "U682c3380036f", "U6240251593cd", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Ud9df8116deba", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Uad577360d968", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "U1c285703fc63", 1.0, -1);
+  graph.write_put_edge("", "U1e41b5f3adff", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Ud04c89aaf453", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "U01814d1ec9ff", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Ud9df8116deba", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Ub93799d9400e", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Ud5b22ebf52f2", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "U6240251593cd", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "U016217c34c6e", 1.0, -1);
+  graph.write_put_edge("", "Uc3c31b8a022f", "U1c285703fc63", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "Ue7a29d5409f2", 1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "U016217c34c6e", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "U9a2c85753a6d", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "U9e42f6dab85a", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "Uc3c31b8a022f", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "Uf5096f6ab14e", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "U9e42f6dab85a", 1.0, -1);
+  graph.write_put_edge("", "U9a89e0679dec", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Udece0afd9a8b", 1.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "U389f9f24b31c", 1.0, -1);
+  graph.write_put_edge("", "U9e42f6dab85a", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "Uadeb43da4abb", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "Uad577360d968", 1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Uf2b0a6b1d423", 1.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "U389f9f24b31c", 1.0, -1);
+  graph.write_put_edge("", "U77a03e9a08af", "Ub01f4ad1b03f", 1.0, -1);
+  graph.write_put_edge("", "U71deb40da828", "U55272fd6c264", 1.0, -1);
+  graph.write_put_edge("", "U71deb40da828", "Ub01f4ad1b03f", 1.0, -1);
+  graph.write_put_edge("", "Uce7e9acd408e", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Uce7e9acd408e", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U04d86c56e1b8", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Ud10b3f42f87b", "Ub9713d01f478", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U1691db0d4d7f", 1.0, -1);
+  graph.write_put_edge("", "U75cddb09a54e", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U75cddb09a54e", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U0bf7eddae79d", "Ub01f4ad1b03f", 1.0, -1);
+  graph.write_put_edge("", "Ue925856b9cd9", "Ucc76e1b73be0", 1.0, -1);
+  graph.write_put_edge("", "U79466f73dc0c", "U01814d1ec9ff", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "U0cd6bd2dde4f", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "U09cf1f359454", 1.0, -1);
+  graph.write_put_edge("", "Uf82dbb4708ba", "U0ae9f5d0bf02", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U55272fd6c264", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U3ea0a229ad85", 1.0, -1);
+  graph.write_put_edge("", "U04d86c56e1b8", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Ucb442106b78c", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U3a466eaf5798", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Ue925856b9cd9", "U1691db0d4d7f", 1.0, -1);
+  graph.write_put_edge("", "Ue925856b9cd9", "U3a466eaf5798", 1.0, -1);
+  graph.write_put_edge("", "Ue925856b9cd9", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U0ae9f5d0bf02", "Ub01f4ad1b03f", 1.0, -1);
+  graph.write_put_edge("", "Ueb139752b907", "U79466f73dc0c", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U0be96c3b9883", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U0cd6bd2dde4f", 0.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U79466f73dc0c", 1.0, -1);
+  graph.write_put_edge("", "U76a293d70033", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U7b30e21179fc", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Ua37f245cf686", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Ua37f245cf686", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Ua37f245cf686", "U55272fd6c264", 1.0, -1);
+  graph.write_put_edge("", "U3be62375581d", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U47746fcce8c0", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Ud9df8116deba", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U01814d1ec9ff", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "U95f3426b8e5d", "B191f781ace43", 1.0, -1);
+  graph.write_put_edge("", "Ucc76e1b73be0", "B83ef002b8120", 1.0, -1);
+  graph.write_put_edge("", "U0ae9f5d0bf02", "Bed48703df71d", 1.0, -1);
+  graph.write_put_edge("", "Uf82dbb4708ba", "B91796a98a225", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Bca63d8a2057b", 1.0, -1);
+}
+
+#[test]
+fn scores_without_recalculate_smoke() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges_with_zero(&mut graph);
+
+  let res: Vec<_> = graph.read_scores(
+    "",
+    "Ue925856b9cd9",
+    "U",
+    true,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
+
+  let n = res.len();
+
+  assert!(n > 2);
+
+  for x in res {
+    println!("{} -> {}: {}, {}, {}, {}", x.0, x.1, x.2, x.3, x.4, x.5);
+  }
+}
+
+#[test]
+fn new_user_without_recalculate_smoke() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges_with_zero(&mut graph);
+
+  graph.write_put_edge("", "U1", "U000000000000", 1.0, -1);
+
+  let res: Vec<_> = graph.read_scores(
+    "",
+    "U1",
+    "U",
+    true,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
+
+  let n = res.len();
+
+  // assert!(n > 2);
+
+  for x in res {
+    println!("{} -> {}: {}, {}, {}, {}", x.0, x.1, x.2, x.3, x.4, x.5);
+  }
+
+  // assert!(false);
 }
 
 #[test]

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -1495,6 +1495,23 @@ fn new_user_with_recalculate() {
 }
 
 #[test]
+fn new_friend() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges_with_zero(&mut graph);
+
+  graph.write_recalculate_zero();
+
+  let (_, _, s0, _, _, _) = graph.read_node_score("", "Ue925856b9cd9", "Ucc76e1b73be0")[0];
+
+  graph.write_put_edge("", "Ue925856b9cd9", "Ucc76e1b73be0", 1.0, -1);
+
+  let (_, _, s1, _, _, _) = graph.read_node_score("", "Ue925856b9cd9", "Ucc76e1b73be0")[0];
+
+  assert_ne!(s0, s1);
+}
+
+#[test]
 fn edge_uncontexted() {
   let mut graph = AugMultiGraph::new();
 

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -1340,7 +1340,24 @@ fn new_user_with_recalculate() {
 }
 
 #[test]
-fn new_friend() {
+fn new_friend_smol() {
+  let mut graph = AugMultiGraph::new();
+
+  graph.write_put_edge("", "Ue925856b9cd9", "Ucc76e1b73be0", 1.0, -1);
+
+  graph.write_recalculate_zero();
+
+  let (_, _, s0, _, _, _) = graph.read_node_score("", "Ue925856b9cd9", "U6d2f25cc4264")[0];
+
+  graph.write_put_edge("", "Ue925856b9cd9", "U6d2f25cc4264", 1.0, -1);
+
+  let (_, _, s1, _, _, _) = graph.read_node_score("", "Ue925856b9cd9", "U6d2f25cc4264")[0];
+
+  assert_ne!(s0, s1);
+}
+
+#[test]
+fn new_friend_big() {
   let mut graph = AugMultiGraph::new();
 
   put_testing_edges_2(&mut graph);
@@ -1883,10 +1900,6 @@ fn mutual_scores_uncontexted() {
   graph.write_put_edge("", "U3", "U2", 2.0, -1);
 
   let res: Vec<_> = graph.read_mutual_scores("", "U1");
-
-  for x in res.iter() {
-    println!("{:?}", x);
-  }
 
   assert_eq!(res.len(), 3);
 

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -1293,8 +1293,6 @@ fn new_user_without_recalculate() {
 
   put_testing_edges_2(&mut graph);
 
-  //  read_scores should return zero opinion data even if the node doesn't exist
-
   let res: Vec<_> = graph.read_scores(
     "",
     "U1",
@@ -1310,7 +1308,7 @@ fn new_user_without_recalculate() {
 
   let n = res.len();
 
-  assert_eq!(n, 0);
+  assert_eq!(n, 1); // Only self-score
 }
 
 #[test]
@@ -1521,8 +1519,8 @@ fn scores_uncontexted() {
 
     match x.1.as_str() {
       "U1" => {
-        assert!(x.2 > 0.2);
-        assert!(x.2 < 0.5);
+        assert!(x.2 > 0.1);
+        assert!(x.2 < 0.4);
       },
 
       "U2" => {
@@ -1885,6 +1883,10 @@ fn mutual_scores_uncontexted() {
   graph.write_put_edge("", "U3", "U2", 2.0, -1);
 
   let res: Vec<_> = graph.read_mutual_scores("", "U1");
+
+  for x in res.iter() {
+    println!("{:?}", x);
+  }
 
   assert_eq!(res.len(), 3);
 

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -1108,177 +1108,7 @@ fn scores_sort_order() {
   }
 }
 
-fn put_testing_edges_with_zero(graph : &mut AugMultiGraph) {
-  graph.write_put_edge("", "U784662a9d229", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ub660dcc736b6", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ub4b17bc06434", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0ae9f5d0bf02", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ue62e5ffad707", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0929c858681e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uf82dbb4708ba", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ucf8af4b3fa12", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0be96c3b9883", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ub4b46ee7a5e4", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U1691db0d4d7f", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U70303578cf3d", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U7725640de5b2", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ub01f4ad1b03f", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U00a73eafb789", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ucc76e1b73be0", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U133f8c421ed0", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U043fbd8f99fa", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U13f1bde6e566", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U5d33a9be1633", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U17b825d673df", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0d2e9e0dc40e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U3ea0a229ad85", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U68c2a35a5c73", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ub9713d01f478", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0ea4876f2b2b", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U6f2df9691c1e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U49f87748a6eb", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ua3974669b55c", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U7f00a4668300", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud3fedd6e69de", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uf5dc346ce127", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ue925856b9cd9", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U323855718209", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U71deb40da828", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ufc33a8cb3e4d", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ub47d8c364c9e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U163b54808a6b", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ub38adbd60723", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Udf36e098c231", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U58c3e7370e32", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U95c43e314793", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uf765bb63af01", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U75cddb09a54e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U01558602b2d5", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U86e3be9101fa", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0bf7eddae79d", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U2db9f2283f6a", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uef1c0af37d4c", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U4506d6073350", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U777590fcd586", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ua18956bd9c25", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U55272fd6c264", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U69218e678fdc", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U29a00cc1c9c2", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U3be62375581d", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U19ad3b903835", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Udecbe941f450", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U948afb314973", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U8af8a7e48e6d", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U57c0388e5cb5", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ub28987fd8681", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U66bb6232f9fc", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uc12f2b363b9c", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U77a03e9a08af", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud10b3f42f87b", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U9de057150efc", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U881eb59c559f", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U3a466eaf5798", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U422adbe0083e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0080a5f2547d", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud21004c2382a", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uadeb43da4abb", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U016217c34c6e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U7a8d8324441d", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uad577360d968", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U861750348e9f", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uc4ebbce44401", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ue55b928fa8dd", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ue87b661973ef", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U3da01fd48941", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U58d7f150b0f9", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ua5cf9177c96e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U04d86c56e1b8", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U7b30e21179fc", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U47746fcce8c0", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ue6cc7bfa0efd", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uef7fbf45ef11", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U9a89e0679dec", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Udb60bbb285ca", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ue7a29d5409f2", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U9e42f6dab85a", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U389f9f24b31c", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U9a2c85753a6d", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uc3c31b8a022f", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Udece0afd9a8b", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U26aca0e369c7", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uf5096f6ab14e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uf2b0a6b1d423", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uaa4e2be7a87a", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0c17798eaab4", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U1c285703fc63", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uc1158424318a", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U80e22da6d8c4", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0d47e4861ef0", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U6d2f25cc4264", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U09cf1f359454", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U01814d1ec9ff", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U99a0f1f7e6ee", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U8a78048d60f7", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U1bcba4fd7175", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U499f24158a40", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U21769235b28d", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U390d75770ac1", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U6d23bed38776", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ued8da07b9559", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U76a293d70033", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U40bb83163d40", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U34252014c05b", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ua37f245cf686", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud7002ae5a86c", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ucc6cc40df2b7", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U46e5959770ad", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U614185021ae5", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ueb139752b907", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U6661263fb410", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U02fbd7c8df4c", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud5b22ebf52f2", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U41784ed376c3", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U9605bd4d1218", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ub93799d9400e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U682c3380036f", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U6240251593cd", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U697c59e5d3d7", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ua12e78308f49", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U9e972ae23870", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud2123c013577", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ub7b49e360599", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud9df8116deba", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uce7e9acd408e", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ube0563a943d9", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uda18fb0fbcee", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Udcc4d659895b", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U1e41b5f3adff", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud04c89aaf453", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U79466f73dc0c", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Uc35c445325f5", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U3c63a9b6115a", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0cd6bd2dde4f", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud5df48b5768c", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ua3e5f30e88c2", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U2cd96f1b2ea6", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud3d487baa4db", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U84ba0b3e06d4", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U638f5c19326f", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U11456af7d414", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U18a178de1dfb", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U67bf00435429", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U5e745dde0c76", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ue40b938f47a4", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U6307b2993c24", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ud1fb013acf2c", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U425e5e1ff39b", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ucc8ea98c2b41", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U3c963c53d335", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ua06b740988b1", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ucb442106b78c", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U0da9b1b0859f", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "U95f3426b8e5d", "U000000000000", 1.0, -1);
-  graph.write_put_edge("", "Ue9e793f3ad14", "U000000000000", 1.0, -1);
+fn put_testing_edges_2(graph : &mut AugMultiGraph) {
   graph.write_put_edge("", "U95f3426b8e5d", "U499f24158a40", 1.0, -1);
   graph.write_put_edge("", "U77a03e9a08af", "U6d2f25cc4264", 1.0, -1);
   graph.write_put_edge("", "Ub47d8c364c9e", "Ub01f4ad1b03f", 1.0, -1);
@@ -1379,7 +1209,6 @@ fn put_testing_edges_with_zero(graph : &mut AugMultiGraph) {
   graph.write_put_edge("", "U3a466eaf5798", "U6d2f25cc4264", 1.0, -1);
   graph.write_put_edge("", "Ue925856b9cd9", "U1691db0d4d7f", 1.0, -1);
   graph.write_put_edge("", "Ue925856b9cd9", "U3a466eaf5798", 1.0, -1);
-  graph.write_put_edge("", "Ue925856b9cd9", "U6d2f25cc4264", 1.0, -1);
   graph.write_put_edge("", "U0ae9f5d0bf02", "Ub01f4ad1b03f", 1.0, -1);
   graph.write_put_edge("", "Ueb139752b907", "U79466f73dc0c", 1.0, -1);
   graph.write_put_edge("", "Ub01f4ad1b03f", "U499f24158a40", 1.0, -1);
@@ -1408,37 +1237,9 @@ fn put_testing_edges_with_zero(graph : &mut AugMultiGraph) {
 fn scores_without_recalculate() {
   let mut graph = AugMultiGraph::new();
 
-  put_testing_edges_with_zero(&mut graph);
+  put_testing_edges_2(&mut graph);
 
-  let res: Vec<_> = graph.read_scores(
-    "",
-    "Ue925856b9cd9",
-    "U",
-    true,
-    100.0,
-    false,
-    -100.0,
-    false,
-    0,
-    u32::MAX,
-  );
-
-  let n = res.len();
-
-  assert!(n > 2);
-
-  for x in res {
-    println!("{} -> {}: {}, {}, {}, {}", x.0, x.1, x.2, x.3, x.4, x.5);
-  }
-}
-
-#[test]
-fn new_user_without_recalculate() {
-  let mut graph = AugMultiGraph::new();
-
-  put_testing_edges_with_zero(&mut graph);
-
-  graph.write_put_edge("", "U1", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U1", "U0", 1.0, -1);
 
   let res: Vec<_> = graph.read_scores(
     "",
@@ -1456,21 +1257,17 @@ fn new_user_without_recalculate() {
   let n = res.len();
 
   assert_eq!(n, 2);
-
-  for x in res {
-    println!("{} -> {}: {}, {}, {}, {}", x.0, x.1, x.2, x.3, x.4, x.5);
-  }
 }
 
 #[test]
-fn new_user_with_recalculate() {
+fn scores_with_recalculate() {
   let mut graph = AugMultiGraph::new();
 
-  put_testing_edges_with_zero(&mut graph);
+  put_testing_edges_2(&mut graph);
 
   graph.write_recalculate_zero();
 
-  graph.write_put_edge("", "U1", "U000000000000", 1.0, -1);
+  graph.write_put_edge("", "U1", "U0", 1.0, -1);
 
   let res: Vec<_> = graph.read_scores(
     "",
@@ -1488,25 +1285,75 @@ fn new_user_with_recalculate() {
   let n = res.len();
 
   assert!(n > 2);
+}
 
-  for x in res {
-    println!("{} -> {}: {}, {}, {}, {}", x.0, x.1, x.2, x.3, x.4, x.5);
-  }
+#[test]
+fn new_user_without_recalculate() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges_2(&mut graph);
+
+  //  read_scores should return zero opinion data even if the node doesn't exist
+
+  let res: Vec<_> = graph.read_scores(
+    "",
+    "U1",
+    "U",
+    true,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
+
+  let n = res.len();
+
+  assert_eq!(n, 0);
+}
+
+#[test]
+fn new_user_with_recalculate() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges_2(&mut graph);
+
+  graph.write_recalculate_zero();
+
+  //  read_scores should return zero opinion data even if the node doesn't exist
+
+  let res: Vec<_> = graph.read_scores(
+    "",
+    "U1",
+    "U",
+    true,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
+
+  let n = res.len();
+
+  assert!(n > 2);
 }
 
 #[test]
 fn new_friend() {
   let mut graph = AugMultiGraph::new();
 
-  put_testing_edges_with_zero(&mut graph);
+  put_testing_edges_2(&mut graph);
 
   graph.write_recalculate_zero();
 
-  let (_, _, s0, _, _, _) = graph.read_node_score("", "Ue925856b9cd9", "Ucc76e1b73be0")[0];
+  let (_, _, s0, _, _, _) = graph.read_node_score("", "Ue925856b9cd9", "U6d2f25cc4264")[0];
 
-  graph.write_put_edge("", "Ue925856b9cd9", "Ucc76e1b73be0", 1.0, -1);
+  graph.write_put_edge("", "Ue925856b9cd9", "U6d2f25cc4264", 1.0, -1);
 
-  let (_, _, s1, _, _, _) = graph.read_node_score("", "Ue925856b9cd9", "Ucc76e1b73be0")[0];
+  let (_, _, s1, _, _, _) = graph.read_node_score("", "Ue925856b9cd9", "U6d2f25cc4264")[0];
 
   assert_ne!(s0, s1);
 }

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -1405,7 +1405,7 @@ fn put_testing_edges_with_zero(graph : &mut AugMultiGraph) {
 }
 
 #[test]
-fn scores_without_recalculate_smoke() {
+fn scores_without_recalculate() {
   let mut graph = AugMultiGraph::new();
 
   put_testing_edges_with_zero(&mut graph);
@@ -1433,7 +1433,7 @@ fn scores_without_recalculate_smoke() {
 }
 
 #[test]
-fn new_user_without_recalculate_smoke() {
+fn new_user_without_recalculate() {
   let mut graph = AugMultiGraph::new();
 
   put_testing_edges_with_zero(&mut graph);
@@ -1455,13 +1455,43 @@ fn new_user_without_recalculate_smoke() {
 
   let n = res.len();
 
-  // assert!(n > 2);
+  assert_eq!(n, 2);
 
   for x in res {
     println!("{} -> {}: {}, {}, {}, {}", x.0, x.1, x.2, x.3, x.4, x.5);
   }
+}
 
-  // assert!(false);
+#[test]
+fn new_user_with_recalculate() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges_with_zero(&mut graph);
+
+  graph.write_recalculate_zero();
+
+  graph.write_put_edge("", "U1", "U000000000000", 1.0, -1);
+
+  let res: Vec<_> = graph.read_scores(
+    "",
+    "U1",
+    "U",
+    true,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
+
+  let n = res.len();
+
+  assert!(n > 2);
+
+  for x in res {
+    println!("{} -> {}: {}, {}, {}, {}", x.0, x.1, x.2, x.3, x.4, x.5);
+  }
 }
 
 #[test]

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -2,1110 +2,873 @@ use crate::operations::*;
 use crate::protocol::*;
 use std::time::SystemTime;
 
-fn put_testing_edges(
-  graph: &mut AugMultiGraph,
-  context: &str,
-) {
-  graph.write_put_edge(context, "U0cd6bd2dde4f", "B7f628ad203b5", 1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "C070e739180d6", 9.0, -1);
-  graph.write_put_edge(context, "U1c285703fc63", "Bad1c69de7837", 7.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B92e4a185c654", 3.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B3c467fb437b2", -1.0, -1);
-  graph.write_put_edge(context, "U585dfead09c6", "C6d52e861b366", -1.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "C78d6fac93d00", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "Cbbf2df46955b", 1.0, -1);
-  graph.write_put_edge(context, "U4f530cfe771e", "B9c01ce5718d1", 0.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Cd6c9d5cba220", 1.0, -1);
-  graph.write_put_edge(context, "Cf4b448ef8618", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "Cbbf2df46955b", 4.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B73a44e2bbd44", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B5a1c1d3d0140", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "U1df3e39ebe59", "Bea16f01b8cc5", 1.0, -1);
-  graph.write_put_edge(context, "Uadeb43da4abb", "Bfae1726e4e87", 1.0, -1);
-  graph.write_put_edge(context, "C599f6e6f6b64", "U26aca0e369c7", 1.0, -1);
-  graph.write_put_edge(context, "U79466f73dc0c", "B7f628ad203b5", 6.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B3c467fb437b2", -1.0, -1);
-  graph.write_put_edge(context, "Ud7002ae5a86c", "B75a44a52fa29", -2.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "C6acd550a4ef3", -1.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "B5eb4c6be535a", 5.0, -1);
-  graph.write_put_edge(context, "B9c01ce5718d1", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U99a0f1f7e6ee", "Bd90a1cf73384", 1.0, -1);
-  graph.write_put_edge(context, "U0e6659929c53", "Cffd169930956", 1.0, -1);
-  graph.write_put_edge(context, "Cd1c25e32ad21", "Ucd424ac24c15", 1.0, -1);
-  graph.write_put_edge(context, "Uac897fe92894", "B9c01ce5718d1", -2.0, -1);
-  graph.write_put_edge(context, "Bc4addf09b79f", "U0cd6bd2dde4f", 1.0, -1);
-  graph.write_put_edge(context, "U638f5c19326f", "B9cade9992fb9", 1.0, -1);
-  graph.write_put_edge(context, "U3c63a9b6115a", "Bad1c69de7837", 2.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "C6acd550a4ef3", 6.0, -1);
-  graph.write_put_edge(context, "U99a0f1f7e6ee", "C4d1d582c53c3", 1.0, -1);
-  graph.write_put_edge(context, "Be2b46c17f1da", "U80e22da6d8c4", 1.0, -1);
-  graph.write_put_edge(context, "B5e7178dd70bb", "Ucbd309d6fcc0", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "U1c285703fc63", -1.0, -1);
-  graph.write_put_edge(context, "C4893c40e481d", "Udece0afd9a8b", 1.0, -1);
-  graph.write_put_edge(context, "U9e42f6dab85a", "B3c467fb437b2", 1.0, -1);
-  graph.write_put_edge(context, "Ue70d59cc8e3f", "B9c01ce5718d1", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Bdf39d0e1daf5", -1.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "B70df5dbab8c3", 1.0, -1);
-  graph.write_put_edge(context, "Uad577360d968", "B5eb4c6be535a", 1.0, -1);
-  graph.write_put_edge(context, "U526f361717a8", "Cee9901f0f22c", 1.0, -1);
-  graph.write_put_edge(context, "C2bbd63b00224", "U80e22da6d8c4", 1.0, -1);
-  graph.write_put_edge(context, "Cb3c476a45037", "Ue40b938f47a4", 1.0, -1);
-  graph.write_put_edge(context, "C22e1102411ce", "U6661263fb410", 1.0, -1);
-  graph.write_put_edge(context, "U57b6f30fc663", "Bed5126bc655d", -1.0, -1);
-  graph.write_put_edge(context, "U6661263fb410", "Cf92f90725ffc", 1.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "C2bbd63b00224", 8.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "Ba5d64165e5d5", -1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "U79466f73dc0c", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B5eb4c6be535a", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B499bfc56e77b", -1.0, -1);
-  graph.write_put_edge(context, "U3c63a9b6115a", "Cf92f90725ffc", 1.0, -1);
-  graph.write_put_edge(context, "Ud04c89aaf453", "B4f14b223b56d", 1.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "Udece0afd9a8b", 1.0, -1);
-  graph.write_put_edge(context, "U38fdca6685ca", "Cf77494dc63d7", 1.0, -1);
-  graph.write_put_edge(context, "U83282a51b600", "Be2b46c17f1da", 0.0, -1);
-  graph.write_put_edge(context, "U83e829a2e822", "B7f628ad203b5", 14.0, -1);
-  graph.write_put_edge(context, "Bc896788cd2ef", "U1bcba4fd7175", 1.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "C67e4476fda28", 6.0, -1);
-  graph.write_put_edge(context, "C9028c7415403", "Udece0afd9a8b", 1.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "Uadeb43da4abb", "B0e230e9108dd", 4.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "C264c56d501db", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B73a44e2bbd44", 1.0, -1);
-  graph.write_put_edge(context, "Ud982a6dee46f", "Be7145faf15cb", 1.0, -1);
-  graph.write_put_edge(context, "B0a87a669fc28", "U34252014c05b", 1.0, -1);
-  graph.write_put_edge(context, "U0e6659929c53", "Cb967536095de", 1.0, -1);
-  graph.write_put_edge(context, "C0f834110f700", "U38fdca6685ca", 1.0, -1);
-  graph.write_put_edge(context, "U72f88cf28226", "Cb11edc3d0bc7", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "C0166be581dd4", 1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "C6a2263dc469e", 2.0, -1);
-  graph.write_put_edge(context, "U526f361717a8", "C52d41a9ad558", 1.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "Cb76829a425d9", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "Cf4b448ef8618", 1.0, -1);
-  graph.write_put_edge(context, "Uadeb43da4abb", "C30e7409c2d5f", 2.0, -1);
-  graph.write_put_edge(context, "U05e4396e2382", "B7f628ad203b5", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Cb11edc3d0bc7", 1.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "B1533941e2773", 1.0, -1);
-  graph.write_put_edge(context, "B506fff6cfc22", "Ub7f9dfb6a7a5", 1.0, -1);
-  graph.write_put_edge(context, "Uad577360d968", "C2bbd63b00224", 9.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "C4f2dafca724f", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Bd7a8bfcf3337", 1.0, -1);
-  graph.write_put_edge(context, "C1ccb4354d684", "Ue202d5b01f8d", 1.0, -1);
-  graph.write_put_edge(context, "Ud5b22ebf52f2", "Cd6c9d5cba220", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Ba5d64165e5d5", -1.0, -1);
-  graph.write_put_edge(context, "Uf5096f6ab14e", "C6aebafa4fe8e", 8.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "C588ffef22463", 1.0, -1);
-  graph.write_put_edge(context, "Ccae34b3da05e", "Ub93799d9400e", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B9c01ce5718d1", 3.0, -1);
-  graph.write_put_edge(context, "Uc35c445325f5", "B75a44a52fa29", 2.0, -1);
-  graph.write_put_edge(context, "U362d375c067c", "Ce06bda6030fe", 1.0, -1);
-  graph.write_put_edge(context, "Uaa4e2be7a87a", "Cfdde53c79a2d", 3.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B75a44a52fa29", 1.0, -1);
-  graph.write_put_edge(context, "Bb5f87c1621d5", "Ub01f4ad1b03f", 1.0, -1);
-  graph.write_put_edge(context, "U016217c34c6e", "B3c467fb437b2", 2.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "Udece0afd9a8b", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B63fbe1427d09", -1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "C5782d559baad", 1.0, -1);
-  graph.write_put_edge(context, "C3b855f713d19", "U704bd6ecde75", 1.0, -1);
-  graph.write_put_edge(context, "U016217c34c6e", "Cb76829a425d9", 2.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "Ba3c4a280657d", 1.0, -1);
-  graph.write_put_edge(context, "U0c17798eaab4", "Udece0afd9a8b", -1.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "Bdf39d0e1daf5", 1.0, -1);
-  graph.write_put_edge(context, "C588ffef22463", "Uef7fbf45ef11", 1.0, -1);
-  graph.write_put_edge(context, "U72f88cf28226", "B3f6f837bc345", 1.0, -1);
-  graph.write_put_edge(context, "Ba3c4a280657d", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Bd90a1cf73384", 3.0, -1);
-  graph.write_put_edge(context, "U638f5c19326f", "B9c01ce5718d1", 2.0, -1);
-  graph.write_put_edge(context, "U83282a51b600", "C9462ca240ceb", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "C54972a5fbc16", 1.0, -1);
-  graph.write_put_edge(context, "Ub93799d9400e", "B9c01ce5718d1", 5.0, -1);
-  graph.write_put_edge(context, "U9e42f6dab85a", "C15d8dfaceb75", 1.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "Be2b46c17f1da", -1.0, -1);
-  graph.write_put_edge(context, "B8a531802473b", "U016217c34c6e", 1.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "Bb78026d99388", -11.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "C4893c40e481d", 4.0, -1);
-  graph.write_put_edge(context, "Cb11edc3d0bc7", "U8a78048d60f7", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Bb1e3630d2f4a", 1.0, -1);
-  graph.write_put_edge(context, "U0cd6bd2dde4f", "B92e4a185c654", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B45d72e29f004", -1.0, -1);
-  graph.write_put_edge(context, "Cab47a458295f", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "Ue55b928fa8dd", "Bed5126bc655d", 3.0, -1);
-  graph.write_put_edge(context, "U016217c34c6e", "U9a89e0679dec", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "U8a78048d60f7", 1.0, -1);
-  graph.write_put_edge(context, "C6aebafa4fe8e", "U9a2c85753a6d", 1.0, -1);
-  graph.write_put_edge(context, "Ucdffb8ab5145", "Cf8fb8c05c116", 1.0, -1);
-  graph.write_put_edge(context, "U0cd6bd2dde4f", "B9c01ce5718d1", 1.0, -1);
-  graph.write_put_edge(context, "U59abf06369c3", "Cda989f4b466d", 1.0, -1);
-  graph.write_put_edge(context, "B4f00e7813add", "U09cf1f359454", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B75a44a52fa29", 3.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "U0c17798eaab4", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "U09cf1f359454", 1.0, -1);
-  graph.write_put_edge(context, "U21769235b28d", "C801f204d0da8", 1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "B3c467fb437b2", 9.0, -1);
-  graph.write_put_edge(context, "U43dcf522b4dd", "B3b3f2ecde430", -1.0, -1);
-  graph.write_put_edge(context, "C264c56d501db", "U1bcba4fd7175", 1.0, -1);
-  graph.write_put_edge(context, "Ua4041a93bdf4", "B9c01ce5718d1", -1.0, -1);
-  graph.write_put_edge(context, "Uc3c31b8a022f", "B45d72e29f004", 3.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "C399b6349ab02", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "Uf5096f6ab14e", "B3b3f2ecde430", 3.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "U8a78048d60f7", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B5eb4c6be535a", -1.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "Cfdde53c79a2d", 6.0, -1);
-  graph.write_put_edge(context, "Udece0afd9a8b", "Uadeb43da4abb", -1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "Bdf39d0e1daf5", -1.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "Cbbf2df46955b", 5.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "C78ad459d3b81", 4.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B5a1c1d3d0140", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B25c85fe0df2d", -1.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "C6acd550a4ef3", 1.0, -1);
-  graph.write_put_edge(context, "B310b66ab31fb", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "C4b2b6fd8fa9a", 1.0, -1);
-  graph.write_put_edge(context, "B70df5dbab8c3", "U09cf1f359454", 1.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "U09cf1f359454", 1.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "B75a44a52fa29", 1.0, -1);
-  graph.write_put_edge(context, "Uadeb43da4abb", "C9462ca240ceb", -1.0, -1);
-  graph.write_put_edge(context, "U9a89e0679dec", "Bb78026d99388", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B491d307dfe01", 3.0, -1);
-  graph.write_put_edge(context, "C7c4d9ca4623e", "U8aa2e2623fa5", 1.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "C1c86825bd597", 1.0, -1);
-  graph.write_put_edge(context, "Udece0afd9a8b", "C357396896bd0", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B4f00e7813add", 1.0, -1);
-  graph.write_put_edge(context, "U1c285703fc63", "U9e42f6dab85a", 1.0, -1);
-  graph.write_put_edge(context, "U1e41b5f3adff", "B310b66ab31fb", 5.0, -1);
-  graph.write_put_edge(context, "Cc2b3069cbe5d", "Ub01f4ad1b03f", 1.0, -1);
-  graph.write_put_edge(context, "Uaa4e2be7a87a", "Uadeb43da4abb", 1.0, -1);
-  graph.write_put_edge(context, "U59abf06369c3", "B7f628ad203b5", 3.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "B45d72e29f004", -9.0, -1);
-  graph.write_put_edge(context, "U05e4396e2382", "Bad1c69de7837", -1.0, -1);
-  graph.write_put_edge(context, "Cd795a41fe71d", "U362d375c067c", 1.0, -1);
-  graph.write_put_edge(context, "U72f88cf28226", "B310b66ab31fb", 1.0, -1);
-  graph.write_put_edge(context, "B4f14b223b56d", "Ud04c89aaf453", 1.0, -1);
-  graph.write_put_edge(context, "U1e41b5f3adff", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "U83e829a2e822", "B0e230e9108dd", -4.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "C6a2263dc469e", 3.0, -1);
-  graph.write_put_edge(context, "C89c123f7bcf5", "U8842ed397bb7", 1.0, -1);
-  graph.write_put_edge(context, "U26aca0e369c7", "C4893c40e481d", 2.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "Uaa4e2be7a87a", -1.0, -1);
-  graph.write_put_edge(context, "Uf5096f6ab14e", "C4893c40e481d", -1.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "B3f6f837bc345", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "C25639690ee57", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "Ud9df8116deba", 1.0, -1);
-  graph.write_put_edge(context, "Ca8ceac412e6f", "U4ba2e4e81c0e", 1.0, -1);
-  graph.write_put_edge(context, "Be29b4af3f7a5", "Uc35c445325f5", 1.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "U02fbd7c8df4c", 1.0, -1);
-  graph.write_put_edge(context, "Cb07d467c1c5e", "U8a78048d60f7", 1.0, -1);
-  graph.write_put_edge(context, "U8aa2e2623fa5", "B9c01ce5718d1", -2.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B3b3f2ecde430", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Cf4b448ef8618", 2.0, -1);
-  graph.write_put_edge(context, "C9a2135edf7ff", "U83282a51b600", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B19ea554faf29", 1.0, -1);
-  graph.write_put_edge(context, "Ba5d64165e5d5", "U1e41b5f3adff", 1.0, -1);
-  graph.write_put_edge(context, "U9605bd4d1218", "B75a44a52fa29", 4.0, -1);
-  graph.write_put_edge(context, "B499bfc56e77b", "Uc1158424318a", 1.0, -1);
-  graph.write_put_edge(context, "U1c285703fc63", "Cd59e6cd7e104", 1.0, -1);
-  graph.write_put_edge(context, "U83e829a2e822", "Be2b46c17f1da", -8.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B45d72e29f004", -1.0, -1);
-  graph.write_put_edge(context, "Cb117f464e558", "U26aca0e369c7", 1.0, -1);
-  graph.write_put_edge(context, "U4ba2e4e81c0e", "B7f628ad203b5", -2.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "B19ea554faf29", 1.0, -1);
-  graph.write_put_edge(context, "Cfd59a206c07d", "U99a0f1f7e6ee", 1.0, -1);
-  graph.write_put_edge(context, "C8ece5c618ac1", "U21769235b28d", 1.0, -1);
-  graph.write_put_edge(context, "Uadeb43da4abb", "Cc9f863ff681b", 2.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "Cdcddfb230cb5", 5.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "Cc9f863ff681b", 1.0, -1);
-  graph.write_put_edge(context, "U26aca0e369c7", "C6acd550a4ef3", 4.0, -1);
-  graph.write_put_edge(context, "C8c753f46c014", "U8842ed397bb7", 1.0, -1);
-  graph.write_put_edge(context, "C78d6fac93d00", "Uc1158424318a", 1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "C357396896bd0", 8.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "Cd59e6cd7e104", 3.0, -1);
-  graph.write_put_edge(context, "Bf3a0a1165271", "U9a89e0679dec", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B70df5dbab8c3", 1.0, -1);
-  graph.write_put_edge(context, "Cb967536095de", "U0e6659929c53", 1.0, -1);
-  graph.write_put_edge(context, "C0b19d314485e", "Uaa4e2be7a87a", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "Bc896788cd2ef", -1.0, -1);
-  graph.write_put_edge(context, "Uc35c445325f5", "B9c01ce5718d1", 4.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "B9c01ce5718d1", 10.0, -1);
-  graph.write_put_edge(context, "C25639690ee57", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "U362d375c067c", "Bad1c69de7837", 0.0, -1);
-  graph.write_put_edge(context, "U1c285703fc63", "C67e4476fda28", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B60d725feca77", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Bfefe4e25c870", 3.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "Cdcddfb230cb5", 4.0, -1);
-  graph.write_put_edge(context, "Uf5096f6ab14e", "Cb14487d862b3", 1.0, -1);
-  graph.write_put_edge(context, "U682c3380036f", "C7986cd8a648a", 1.0, -1);
-  graph.write_put_edge(context, "U02fbd7c8df4c", "Bd7a8bfcf3337", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "Cbbf2df46955b", 5.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "U6240251593cd", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "C8d80016b8292", 1.0, -1);
-  graph.write_put_edge(context, "Uc35c445325f5", "B8a531802473b", -5.0, -1);
-  graph.write_put_edge(context, "U704bd6ecde75", "B9c01ce5718d1", -1.0, -1);
-  graph.write_put_edge(context, "U77f496546efa", "B9c01ce5718d1", -1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B7f628ad203b5", -1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B10d3f548efc4", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "Cd06fea6a395f", 9.0, -1);
-  graph.write_put_edge(context, "U7cdd7999301e", "B7f628ad203b5", 1.0, -1);
-  graph.write_put_edge(context, "U526f361717a8", "Cf40e8fb326bc", 1.0, -1);
-  graph.write_put_edge(context, "B944097cdd968", "Ue40b938f47a4", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B3f6f837bc345", 1.0, -1);
-  graph.write_put_edge(context, "U6661263fb410", "Cc01e00342d63", 1.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "Cb76829a425d9", -1.0, -1);
-  graph.write_put_edge(context, "Ccb7dc40f1513", "U6661263fb410", 1.0, -1);
-  graph.write_put_edge(context, "U83282a51b600", "C9a2135edf7ff", 1.0, -1);
-  graph.write_put_edge(context, "Cb76829a425d9", "Ue7a29d5409f2", 1.0, -1);
-  graph.write_put_edge(context, "B45d72e29f004", "U26aca0e369c7", 1.0, -1);
-  graph.write_put_edge(context, "Ue6cc7bfa0efd", "B5e7178dd70bb", -7.0, -1);
-  graph.write_put_edge(context, "Uac897fe92894", "Be2b46c17f1da", 2.0, -1);
-  graph.write_put_edge(context, "B73a44e2bbd44", "U8a78048d60f7", 1.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "C399b6349ab02", 5.0, -1);
-  graph.write_put_edge(context, "Cfa08a39f9bb9", "Ubebfe0c8fc29", 1.0, -1);
-  graph.write_put_edge(context, "Cdcddfb230cb5", "Udece0afd9a8b", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Bb5f87c1621d5", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "C78d6fac93d00", 2.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B3c467fb437b2", -1.0, -1);
-  graph.write_put_edge(context, "C0cd490b5fb6a", "Uad577360d968", 1.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "Be2b46c17f1da", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B499bfc56e77b", -1.0, -1);
-  graph.write_put_edge(context, "C2cb023b6bcef", "Ucb84c094edba", 1.0, -1);
-  graph.write_put_edge(context, "U016217c34c6e", "C4e0db8dec53e", 4.0, -1);
-  graph.write_put_edge(context, "Cc931cd2de143", "Ud7002ae5a86c", 1.0, -1);
-  graph.write_put_edge(context, "U0c17798eaab4", "C4893c40e481d", 7.0, -1);
-  graph.write_put_edge(context, "U1c285703fc63", "U016217c34c6e", 1.0, -1);
-  graph.write_put_edge(context, "U682c3380036f", "U6240251593cd", 1.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "B4f00e7813add", 1.0, -1);
-  graph.write_put_edge(context, "Ud7002ae5a86c", "Cc931cd2de143", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "B79efabc4d8bf", 1.0, -1);
-  graph.write_put_edge(context, "U3de789cac826", "B9c01ce5718d1", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "C888c86d096d0", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "C10872dc9b863", 1.0, -1);
-  graph.write_put_edge(context, "B0e230e9108dd", "U9a89e0679dec", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "C2e31b4b1658f", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B25c85fe0df2d", -1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "C81f3f954b643", 1.0, -1);
-  graph.write_put_edge(context, "C0a576fc389d9", "U1bcba4fd7175", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B3f6f837bc345", 1.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "C6d52e861b366", 3.0, -1);
-  graph.write_put_edge(context, "U362d375c067c", "Cd795a41fe71d", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B3b3f2ecde430", -1.0, -1);
-  graph.write_put_edge(context, "U585dfead09c6", "B9c01ce5718d1", 2.0, -1);
-  graph.write_put_edge(context, "Cfd47f43ac9cf", "U704bd6ecde75", 1.0, -1);
-  graph.write_put_edge(context, "U72f88cf28226", "Cd6c9d5cba220", 1.0, -1);
-  graph.write_put_edge(context, "Cdd49e516723a", "U704bd6ecde75", 1.0, -1);
-  graph.write_put_edge(context, "U26aca0e369c7", "Be2b46c17f1da", 7.0, -1);
-  graph.write_put_edge(context, "Uad577360d968", "C588ffef22463", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B3c467fb437b2", -1.0, -1);
-  graph.write_put_edge(context, "Bf34ee3bfc12b", "U6240251593cd", 1.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "Bb78026d99388", 9.0, -1);
-  graph.write_put_edge(context, "Ue202d5b01f8d", "B9c01ce5718d1", 2.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B310b66ab31fb", 1.0, -1);
-  graph.write_put_edge(context, "U35eb26fc07b4", "C90290100a953", 1.0, -1);
-  graph.write_put_edge(context, "Cc9f863ff681b", "Uc1158424318a", 1.0, -1);
-  graph.write_put_edge(context, "Uf5ee43a1b729", "C9218f86f6286", 1.0, -1);
-  graph.write_put_edge(context, "C888c86d096d0", "U7a8d8324441d", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "Bfefe4e25c870", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "C6f84810d3cd9", 1.0, -1);
-  graph.write_put_edge(context, "Cd6c9d5cba220", "Ud5b22ebf52f2", 1.0, -1);
-  graph.write_put_edge(context, "U99a0f1f7e6ee", "C96bdee4f11e2", -18.0, -1);
-  graph.write_put_edge(context, "U4a82930ca419", "C2d9ab331aed7", 1.0, -1);
-  graph.write_put_edge(context, "C4818c4ed20bf", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "Ucd424ac24c15", "Cd1c25e32ad21", 1.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "Bad1c69de7837", 2.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "Cfdde53c79a2d", 5.0, -1);
-  graph.write_put_edge(context, "U5c827d7de115", "B69723edfec8a", 1.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "Cd4417a5d718e", 5.0, -1);
-  graph.write_put_edge(context, "Ue202d5b01f8d", "C1ccb4354d684", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B9c01ce5718d1", 4.0, -1);
-  graph.write_put_edge(context, "Udece0afd9a8b", "Cdcddfb230cb5", 1.0, -1);
-  graph.write_put_edge(context, "C81f3f954b643", "U09cf1f359454", 1.0, -1);
-  graph.write_put_edge(context, "U02fbd7c8df4c", "B75a44a52fa29", 7.0, -1);
-  graph.write_put_edge(context, "U1c285703fc63", "C30e7409c2d5f", 4.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Be5bb2f3d56cb", -1.0, -1);
-  graph.write_put_edge(context, "B10d3f548efc4", "U99a0f1f7e6ee", 1.0, -1);
-  graph.write_put_edge(context, "Uc3c31b8a022f", "B3c467fb437b2", -1.0, -1);
-  graph.write_put_edge(context, "C90290100a953", "U35eb26fc07b4", 1.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "B310b66ab31fb", 1.0, -1);
-  graph.write_put_edge(context, "U35eb26fc07b4", "Be2b46c17f1da", 0.0, -1);
-  graph.write_put_edge(context, "Ccbd85b8513f3", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "Bc896788cd2ef", 1.0, -1);
-  graph.write_put_edge(context, "U0cd6bd2dde4f", "C7062e90f7422", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "Be2b46c17f1da", -1.0, -1);
-  graph.write_put_edge(context, "C4d1d582c53c3", "U99a0f1f7e6ee", 1.0, -1);
-  graph.write_put_edge(context, "U59abf06369c3", "Cb117f464e558", -3.0, -1);
-  graph.write_put_edge(context, "B491d307dfe01", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "B25c85fe0df2d", "Uef7fbf45ef11", 1.0, -1);
-  graph.write_put_edge(context, "Bdf39d0e1daf5", "Uc1158424318a", 1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "C3e84102071d1", 6.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B63fbe1427d09", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Cd5983133fb67", 1.0, -1);
-  graph.write_put_edge(context, "Cc616eded7a99", "U0f63ee3db59b", 1.0, -1);
-  graph.write_put_edge(context, "U34252014c05b", "B19ea554faf29", 1.0, -1);
-  graph.write_put_edge(context, "U0f63ee3db59b", "B9c01ce5718d1", -4.0, -1);
-  graph.write_put_edge(context, "Uf6ce05bc4e5a", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Cbce32a9b256a", 1.0, -1);
-  graph.write_put_edge(context, "U9a89e0679dec", "Bf3a0a1165271", 1.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "B63fbe1427d09", -3.0, -1);
-  graph.write_put_edge(context, "U0cd6bd2dde4f", "Bc4addf09b79f", 1.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "B4f00e7813add", 3.0, -1);
-  graph.write_put_edge(context, "U9e42f6dab85a", "Bad1c69de7837", 3.0, -1);
-  graph.write_put_edge(context, "U26aca0e369c7", "C599f6e6f6b64", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "Bdf39d0e1daf5", -1.0, -1);
-  graph.write_put_edge(context, "Uf8bf10852d43", "B253177f84f08", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "B7f628ad203b5", 1.0, -1);
-  graph.write_put_edge(context, "U43dcf522b4dd", "B9c01ce5718d1", 2.0, -1);
-  graph.write_put_edge(context, "C13e2a35d917a", "Uf6ce05bc4e5a", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B8a531802473b", -1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "C247501543b60", 1.0, -1);
-  graph.write_put_edge(context, "C2e31b4b1658f", "U8a78048d60f7", 1.0, -1);
-  graph.write_put_edge(context, "C94bb73c10a06", "Uef7fbf45ef11", 1.0, -1);
-  graph.write_put_edge(context, "C357396896bd0", "Udece0afd9a8b", 1.0, -1);
-  graph.write_put_edge(context, "C6acd550a4ef3", "Uc1158424318a", 1.0, -1);
-  graph.write_put_edge(context, "U016217c34c6e", "C3e84102071d1", 1.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "Bc4addf09b79f", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "Cfe90cbd73eab", 1.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "C30e7409c2d5f", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "Bf3a0a1165271", -1.0, -1);
-  graph.write_put_edge(context, "Uadeb43da4abb", "C2bbd63b00224", 7.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Be2b46c17f1da", -1.0, -1);
-  graph.write_put_edge(context, "Caa62fc21e191", "U4ba2e4e81c0e", 1.0, -1);
-  graph.write_put_edge(context, "U02fbd7c8df4c", "Bad1c69de7837", -5.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "B73a44e2bbd44", 3.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "U9e42f6dab85a", 1.0, -1);
-  graph.write_put_edge(context, "Cb95e21215efa", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "B1533941e2773", "U79466f73dc0c", 1.0, -1);
-  graph.write_put_edge(context, "U1e41b5f3adff", "Ba5d64165e5d5", 1.0, -1);
-  graph.write_put_edge(context, "U682c3380036f", "Bf34ee3bfc12b", 4.0, -1);
-  graph.write_put_edge(context, "Udece0afd9a8b", "Uc3c31b8a022f", -1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "U1c285703fc63", 1.0, -1);
-  graph.write_put_edge(context, "U9ce5721e93cf", "B68247950d9c0", 1.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "Uc3c31b8a022f", 1.0, -1);
-  graph.write_put_edge(context, "U9a89e0679dec", "Cd06fea6a395f", -1.0, -1);
-  graph.write_put_edge(context, "U9e42f6dab85a", "C6a2263dc469e", 5.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B0a87a669fc28", 1.0, -1);
-  graph.write_put_edge(context, "Cf40e8fb326bc", "U526f361717a8", 1.0, -1);
-  graph.write_put_edge(context, "U4ba2e4e81c0e", "Cb117f464e558", 1.0, -1);
-  graph.write_put_edge(context, "U95f3426b8e5d", "B9c01ce5718d1", 2.0, -1);
-  graph.write_put_edge(context, "C524134905072", "Ucb84c094edba", 1.0, -1);
-  graph.write_put_edge(context, "Cd59e6cd7e104", "U80e22da6d8c4", 1.0, -1);
-  graph.write_put_edge(context, "U9a89e0679dec", "Cbbf2df46955b", -1.0, -1);
-  graph.write_put_edge(context, "Cbe89905f07d3", "Ub01f4ad1b03f", 1.0, -1);
-  graph.write_put_edge(context, "Bed5126bc655d", "Uc4ebbce44401", 1.0, -1);
-  graph.write_put_edge(context, "U9605bd4d1218", "B8a531802473b", 2.0, -1);
-  graph.write_put_edge(context, "Ub93799d9400e", "B73a44e2bbd44", 5.0, -1);
-  graph.write_put_edge(context, "Cee9901f0f22c", "U526f361717a8", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Cc2b3069cbe5d", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "B3b3f2ecde430", 1.0, -1);
-  graph.write_put_edge(context, "Ubebfe0c8fc29", "Cfa08a39f9bb9", 1.0, -1);
-  graph.write_put_edge(context, "U95f3426b8e5d", "Be7bc0cfecab3", 1.0, -1);
-  graph.write_put_edge(context, "C6587e913fbbe", "U6661263fb410", 1.0, -1);
-  graph.write_put_edge(context, "U0cd6bd2dde4f", "C5782d559baad", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B25c85fe0df2d", -1.0, -1);
-  graph.write_put_edge(context, "U016217c34c6e", "B8a531802473b", 1.0, -1);
-  graph.write_put_edge(context, "Ccc25a77bfa2a", "U77f496546efa", 1.0, -1);
-  graph.write_put_edge(context, "U6240251593cd", "Bf34ee3bfc12b", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "C357396896bd0", 1.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "Cb76829a425d9", 8.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "U016217c34c6e", 1.0, -1);
-  graph.write_put_edge(context, "Ucdffb8ab5145", "B9c01ce5718d1", 2.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "B75a44a52fa29", 1.0, -1);
-  graph.write_put_edge(context, "Cac6ca02355da", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Bc4addf09b79f", 1.0, -1);
-  graph.write_put_edge(context, "U0c17798eaab4", "U389f9f24b31c", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Ud9df8116deba", 1.0, -1);
-  graph.write_put_edge(context, "Ucd424ac24c15", "B9c01ce5718d1", 2.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "B9c01ce5718d1", 9.0, -1);
-  graph.write_put_edge(context, "U3c63a9b6115a", "B75a44a52fa29", 5.0, -1);
-  graph.write_put_edge(context, "Bea16f01b8cc5", "U1df3e39ebe59", 1.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "C3fd1fdebe0e9", 9.0, -1);
-  graph.write_put_edge(context, "Cffd169930956", "U0e6659929c53", 1.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "B3b3f2ecde430", -3.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "C4e0db8dec53e", 1.0, -1);
-  graph.write_put_edge(context, "U83282a51b600", "B9c01ce5718d1", -1.0, -1);
-  graph.write_put_edge(context, "Uf5096f6ab14e", "U9e42f6dab85a", -1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "Bfefe4e25c870", 4.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "C070e739180d6", 1.0, -1);
-  graph.write_put_edge(context, "C8343a6a576ff", "U02fbd7c8df4c", 1.0, -1);
-  graph.write_put_edge(context, "Udece0afd9a8b", "C599f6e6f6b64", 2.0, -1);
-  graph.write_put_edge(context, "U77f496546efa", "C9462ca240ceb", -1.0, -1);
-  graph.write_put_edge(context, "Cc42c3eeb9d20", "U8a78048d60f7", 1.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "Ce1a7d8996eb0", -1.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "B70df5dbab8c3", 2.0, -1);
-  graph.write_put_edge(context, "Uaa4e2be7a87a", "C35678a54ef5f", 1.0, -1);
-  graph.write_put_edge(context, "U72f88cf28226", "C7722465c957a", 1.0, -1);
-  graph.write_put_edge(context, "U9605bd4d1218", "C801f204d0da8", 3.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B10d3f548efc4", 3.0, -1);
-  graph.write_put_edge(context, "U9a89e0679dec", "U7a8d8324441d", 1.0, -1);
-  graph.write_put_edge(context, "Be7145faf15cb", "Ud982a6dee46f", 1.0, -1);
-  graph.write_put_edge(context, "Cd06fea6a395f", "Uaa4e2be7a87a", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "C78ad459d3b81", 6.0, -1);
-  graph.write_put_edge(context, "Bb1e3630d2f4a", "U34252014c05b", 1.0, -1);
-  graph.write_put_edge(context, "U6661263fb410", "B75a44a52fa29", 3.0, -1);
-  graph.write_put_edge(context, "Uadeb43da4abb", "Bd49e3dac97b0", 1.0, -1);
-  graph.write_put_edge(context, "Ub93799d9400e", "Cd4417a5d718e", 1.0, -1);
-  graph.write_put_edge(context, "C399b6349ab02", "Uf2b0a6b1d423", 1.0, -1);
-  graph.write_put_edge(context, "B79efabc4d8bf", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U83282a51b600", "C16dfdd8077c8", 1.0, -1);
-  graph.write_put_edge(context, "U1c285703fc63", "U9a2c85753a6d", 1.0, -1);
-  graph.write_put_edge(context, "B19ea554faf29", "U34252014c05b", 1.0, -1);
-  graph.write_put_edge(context, "B75a44a52fa29", "U01814d1ec9ff", 1.0, -1);
-  graph.write_put_edge(context, "C35678a54ef5f", "Uaa4e2be7a87a", 1.0, -1);
-  graph.write_put_edge(context, "Bc173d5552e2e", "U95f3426b8e5d", 1.0, -1);
-  graph.write_put_edge(context, "Uc3c31b8a022f", "Bb78026d99388", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "Be5bb2f3d56cb", -1.0, -1);
-  graph.write_put_edge(context, "Cb62aea64ea97", "U0e6659929c53", 1.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "B25c85fe0df2d", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B8a531802473b", -1.0, -1);
-  graph.write_put_edge(context, "C5127d08eb786", "Ucd424ac24c15", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "Be2b46c17f1da", 5.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "U1c285703fc63", 1.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "C6a2263dc469e", 1.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "B0e230e9108dd", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Uad577360d968", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B4f14b223b56d", -1.0, -1);
-  graph.write_put_edge(context, "B3c467fb437b2", "U9e42f6dab85a", 1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "C30fef1977b4a", 8.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B19ea554faf29", 3.0, -1);
-  graph.write_put_edge(context, "U6240251593cd", "B9c01ce5718d1", -4.0, -1);
-  graph.write_put_edge(context, "U99a0f1f7e6ee", "C1f41b842849c", 1.0, -1);
-  graph.write_put_edge(context, "Uac897fe92894", "Cb117f464e558", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "U0cd6bd2dde4f", 1.0, -1);
-  graph.write_put_edge(context, "Ucb84c094edba", "C524134905072", 1.0, -1);
-  graph.write_put_edge(context, "B19d70698e3d8", "Uf8bf10852d43", 1.0, -1);
-  graph.write_put_edge(context, "Cda989f4b466d", "U59abf06369c3", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B1533941e2773", 3.0, -1);
-  graph.write_put_edge(context, "U83e829a2e822", "B5eb4c6be535a", 3.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "Bd7a8bfcf3337", 3.0, -1);
-  graph.write_put_edge(context, "Cfdde53c79a2d", "Uef7fbf45ef11", 1.0, -1);
-  graph.write_put_edge(context, "Ue6cc7bfa0efd", "B30bf91bf5845", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B3b3f2ecde430", -1.0, -1);
-  graph.write_put_edge(context, "C63e21d051dda", "U638f5c19326f", 1.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "C30e7409c2d5f", 9.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "C9028c7415403", 3.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "Bd49e3dac97b0", -1.0, -1);
-  graph.write_put_edge(context, "C279db553a831", "U99a0f1f7e6ee", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B45d72e29f004", -1.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "B491d307dfe01", -1.0, -1);
-  graph.write_put_edge(context, "U99a0f1f7e6ee", "Cfd59a206c07d", 1.0, -1);
-  graph.write_put_edge(context, "C52d41a9ad558", "U526f361717a8", 1.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "Uc3c31b8a022f", -1.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "C0a576fc389d9", 1.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "C94bb73c10a06", 3.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Ud5b22ebf52f2", 1.0, -1);
-  graph.write_put_edge(context, "Uf8bf10852d43", "B4115d364e05b", 1.0, -1);
-  graph.write_put_edge(context, "U57b6f30fc663", "B30bf91bf5845", 1.0, -1);
-  graph.write_put_edge(context, "U72f88cf28226", "U6d2f25cc4264", 0.0, -1);
-  graph.write_put_edge(context, "U3c63a9b6115a", "Be5bb2f3d56cb", 1.0, -1);
-  graph.write_put_edge(context, "C7722465c957a", "U72f88cf28226", 1.0, -1);
-  graph.write_put_edge(context, "Ub7f9dfb6a7a5", "B506fff6cfc22", 1.0, -1);
-  graph.write_put_edge(context, "Udece0afd9a8b", "C9028c7415403", 1.0, -1);
-  graph.write_put_edge(context, "U79466f73dc0c", "B45d72e29f004", 5.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B3f6f837bc345", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B4f14b223b56d", -1.0, -1);
-  graph.write_put_edge(context, "U6661263fb410", "C31dac67e313b", 1.0, -1);
-  graph.write_put_edge(context, "C55a114ca6e7c", "U0e6659929c53", 1.0, -1);
-  graph.write_put_edge(context, "C4b2b6fd8fa9a", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U9e42f6dab85a", "C0b19d314485e", -1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "Ba3c4a280657d", 2.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B70df5dbab8c3", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "C30fef1977b4a", 1.0, -1);
-  graph.write_put_edge(context, "Uc35c445325f5", "Be29b4af3f7a5", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "B5eb4c6be535a", 1.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "Cdcddfb230cb5", 3.0, -1);
-  graph.write_put_edge(context, "U9605bd4d1218", "Bd7a8bfcf3337", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "B9c01ce5718d1", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "B3b3f2ecde430", 9.0, -1);
-  graph.write_put_edge(context, "U83282a51b600", "B45d72e29f004", -1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B60d725feca77", -1.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "Cd59e6cd7e104", 1.0, -1);
-  graph.write_put_edge(context, "U26aca0e369c7", "C9028c7415403", 8.0, -1);
-  graph.write_put_edge(context, "B9cade9992fb9", "U638f5c19326f", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B0e230e9108dd", -1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "U79466f73dc0c", "Be2b46c17f1da", 4.0, -1);
-  graph.write_put_edge(context, "C9218f86f6286", "Uf5ee43a1b729", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "Bb78026d99388", -1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "B3b3f2ecde430", 6.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Bd49e3dac97b0", -1.0, -1);
-  graph.write_put_edge(context, "Uf5096f6ab14e", "C9462ca240ceb", 1.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "B0e230e9108dd", -1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "Uf5096f6ab14e", 1.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "Uf2b0a6b1d423", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Bd90a1cf73384", 1.0, -1);
-  graph.write_put_edge(context, "Ucb84c094edba", "C2cb023b6bcef", 1.0, -1);
-  graph.write_put_edge(context, "Ubebfe0c8fc29", "Bfefe4e25c870", 3.0, -1);
-  graph.write_put_edge(context, "U9e42f6dab85a", "C070e739180d6", 2.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "C6f84810d3cd9", 1.0, -1);
-  graph.write_put_edge(context, "U14a3c81256ab", "B9c01ce5718d1", 0.0, -1);
-  graph.write_put_edge(context, "Cd5983133fb67", "U8a78048d60f7", 1.0, -1);
-  graph.write_put_edge(context, "U0cd6bd2dde4f", "B75a44a52fa29", 1.0, -1);
-  graph.write_put_edge(context, "Ue7a29d5409f2", "Ce1a7d8996eb0", 5.0, -1);
-  graph.write_put_edge(context, "Ue40b938f47a4", "B9c01ce5718d1", 0.0, -1);
-  graph.write_put_edge(context, "U0e6659929c53", "Cb62aea64ea97", 1.0, -1);
-  graph.write_put_edge(context, "C1c86825bd597", "U01814d1ec9ff", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "Bb78026d99388", -1.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "Cbce32a9b256a", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "C96bdee4f11e2", 1.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "C4893c40e481d", 3.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "B7f628ad203b5", 7.0, -1);
-  graph.write_put_edge(context, "Uad577360d968", "Bad1c69de7837", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "Cdeab5b39cc2a", 1.0, -1);
-  graph.write_put_edge(context, "B7f628ad203b5", "U7a8d8324441d", 1.0, -1);
-  graph.write_put_edge(context, "Udece0afd9a8b", "C4893c40e481d", 1.0, -1);
-  graph.write_put_edge(context, "C96bdee4f11e2", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B0e230e9108dd", -1.0, -1);
-  graph.write_put_edge(context, "U02fbd7c8df4c", "C8343a6a576ff", 1.0, -1);
-  graph.write_put_edge(context, "C30fef1977b4a", "U7a8d8324441d", 1.0, -1);
-  graph.write_put_edge(context, "U77f496546efa", "Ccc25a77bfa2a", 1.0, -1);
-  graph.write_put_edge(context, "Uf6ce05bc4e5a", "C13e2a35d917a", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "Cfe90cbd73eab", 1.0, -1);
-  graph.write_put_edge(context, "U0c17798eaab4", "B3c467fb437b2", 2.0, -1);
-  graph.write_put_edge(context, "U9e42f6dab85a", "U80e22da6d8c4", 1.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "Cfdde53c79a2d", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "C94bb73c10a06", 9.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Bb78026d99388", -1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B499bfc56e77b", -1.0, -1);
-  graph.write_put_edge(context, "U0c17798eaab4", "Ce1a7d8996eb0", 6.0, -1);
-  graph.write_put_edge(context, "C7062e90f7422", "U01814d1ec9ff", 1.0, -1);
-  graph.write_put_edge(context, "Cf8fb8c05c116", "Ucdffb8ab5145", 1.0, -1);
-  graph.write_put_edge(context, "B60d725feca77", "U80e22da6d8c4", 1.0, -1);
-  graph.write_put_edge(context, "C070e739180d6", "U80e22da6d8c4", 1.0, -1);
-  graph.write_put_edge(context, "C3e84102071d1", "U016217c34c6e", 1.0, -1);
-  graph.write_put_edge(context, "B69723edfec8a", "U5c827d7de115", 1.0, -1);
-  graph.write_put_edge(context, "U0c17798eaab4", "B0e230e9108dd", 3.0, -1);
-  graph.write_put_edge(context, "U0c17798eaab4", "C4e0db8dec53e", 1.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "Cfc639b9aa3e0", 1.0, -1);
-  graph.write_put_edge(context, "Uad577360d968", "C0cd490b5fb6a", 1.0, -1);
-  graph.write_put_edge(context, "Uc3c31b8a022f", "U1c285703fc63", 1.0, -1);
-  graph.write_put_edge(context, "U3c63a9b6115a", "B9c01ce5718d1", 3.0, -1);
-  graph.write_put_edge(context, "B3b3f2ecde430", "U7a8d8324441d", 1.0, -1);
-  graph.write_put_edge(context, "U38fdca6685ca", "B9c01ce5718d1", 0.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "C78ad459d3b81", 1.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "C67e4476fda28", -1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "U01814d1ec9ff", 1.0, -1);
-  graph.write_put_edge(context, "U4ba2e4e81c0e", "Ca8ceac412e6f", 1.0, -1);
-  graph.write_put_edge(context, "Cfe90cbd73eab", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U79466f73dc0c", "B1533941e2773", 1.0, -1);
-  graph.write_put_edge(context, "C8d80016b8292", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "Uf6ce05bc4e5a", "Bf843e315d71b", 1.0, -1);
-  graph.write_put_edge(context, "U6661263fb410", "C6587e913fbbe", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Bb1e3630d2f4a", 3.0, -1);
-  graph.write_put_edge(context, "Ucd424ac24c15", "C5127d08eb786", 1.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "C4e0db8dec53e", 4.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "Bad1c69de7837", -1.0, -1);
-  graph.write_put_edge(context, "Ud7002ae5a86c", "C7a807e462b65", 1.0, -1);
-  graph.write_put_edge(context, "C3c17b70c3357", "U3de789cac826", 1.0, -1);
-  graph.write_put_edge(context, "Bd90a1cf73384", "U99a0f1f7e6ee", 1.0, -1);
-  graph.write_put_edge(context, "U83282a51b600", "B7f628ad203b5", 1.0, -1);
-  graph.write_put_edge(context, "U26aca0e369c7", "Cb117f464e558", 1.0, -1);
-  graph.write_put_edge(context, "Ce1a7d8996eb0", "Uf5096f6ab14e", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "Bad1c69de7837", -1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B25c85fe0df2d", -1.0, -1);
-  graph.write_put_edge(context, "U95f3426b8e5d", "Bc173d5552e2e", 1.0, -1);
-  graph.write_put_edge(context, "U9a89e0679dec", "C6aebafa4fe8e", 8.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "B8a531802473b", 8.0, -1);
-  graph.write_put_edge(context, "Ub93799d9400e", "B75a44a52fa29", 5.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Bf34ee3bfc12b", 1.0, -1);
-  graph.write_put_edge(context, "U34252014c05b", "B0a87a669fc28", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Cbe89905f07d3", 1.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "U7a8d8324441d", 1.0, -1);
-  graph.write_put_edge(context, "Uf5096f6ab14e", "Ce1a7d8996eb0", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B4f00e7813add", 1.0, -1);
-  graph.write_put_edge(context, "Bd7a8bfcf3337", "U02fbd7c8df4c", 1.0, -1);
-  graph.write_put_edge(context, "C2d9ab331aed7", "U4a82930ca419", 1.0, -1);
-  graph.write_put_edge(context, "C247501543b60", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "Cfdde53c79a2d", 4.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "C613f00c1333c", 1.0, -1);
-  graph.write_put_edge(context, "C31dac67e313b", "U6661263fb410", 1.0, -1);
-  graph.write_put_edge(context, "C67e4476fda28", "U1c285703fc63", 1.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "C3e84102071d1", 4.0, -1);
-  graph.write_put_edge(context, "U9605bd4d1218", "Cab47a458295f", 3.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "C992d8370db6b", 1.0, -1);
-  graph.write_put_edge(context, "Cbce32a9b256a", "U389f9f24b31c", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B63fbe1427d09", -1.0, -1);
-  graph.write_put_edge(context, "B63fbe1427d09", "U1c285703fc63", 1.0, -1);
-  graph.write_put_edge(context, "Uf5096f6ab14e", "B60d725feca77", 8.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "Bfefe4e25c870", 5.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B9c01ce5718d1", 2.0, -1);
-  graph.write_put_edge(context, "Uac897fe92894", "B7f628ad203b5", 1.0, -1);
-  graph.write_put_edge(context, "B8120aa1edccb", "Ue40b938f47a4", 1.0, -1);
-  graph.write_put_edge(context, "Ueb139752b907", "U79466f73dc0c", 1.0, -1);
-  graph.write_put_edge(context, "U0e6659929c53", "B9c01ce5718d1", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B491d307dfe01", 2.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "B73a44e2bbd44", 1.0, -1);
-  graph.write_put_edge(context, "U38fdca6685ca", "C958e7588ae1c", 1.0, -1);
-  graph.write_put_edge(context, "U35eb26fc07b4", "B60d725feca77", 1.0, -1);
-  graph.write_put_edge(context, "Cdeab5b39cc2a", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U0f63ee3db59b", "Cbcf72c7e6061", 1.0, -1);
-  graph.write_put_edge(context, "C4e0db8dec53e", "U0c17798eaab4", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B7f628ad203b5", -1.0, -1);
-  graph.write_put_edge(context, "C472b59eeafa5", "U4a82930ca419", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "C247501543b60", 1.0, -1);
-  graph.write_put_edge(context, "Cfc639b9aa3e0", "U389f9f24b31c", 1.0, -1);
-  graph.write_put_edge(context, "U95f3426b8e5d", "B23b74174e659", 1.0, -1);
-  graph.write_put_edge(context, "U99deecf5a281", "B9c01ce5718d1", 1.0, -1);
-  graph.write_put_edge(context, "Bfefe4e25c870", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "Ua12e78308f49", "B75a44a52fa29", 4.0, -1);
-  graph.write_put_edge(context, "Uaa4e2be7a87a", "Cd06fea6a395f", 1.0, -1);
-  graph.write_put_edge(context, "U682c3380036f", "B75a44a52fa29", 2.0, -1);
-  graph.write_put_edge(context, "Ue202d5b01f8d", "C637133747308", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "Cab47a458295f", 1.0, -1);
-  graph.write_put_edge(context, "U0c17798eaab4", "Cd06fea6a395f", 8.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Bd7a8bfcf3337", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "U01814d1ec9ff", 1.0, -1);
-  graph.write_put_edge(context, "Uf5ee43a1b729", "B47cc49866c37", 1.0, -1);
-  graph.write_put_edge(context, "Uac897fe92894", "C9462ca240ceb", 0.0, -1);
-  graph.write_put_edge(context, "U21769235b28d", "C481cd737c873", 1.0, -1);
-  graph.write_put_edge(context, "C6f84810d3cd9", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "Uc3c31b8a022f", "C78d6fac93d00", 3.0, -1);
-  graph.write_put_edge(context, "Udece0afd9a8b", "C4f2dafca724f", 8.0, -1);
-  graph.write_put_edge(context, "Uaa4e2be7a87a", "B0e230e9108dd", 2.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Bb78026d99388", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Cdcddfb230cb5", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "U0cd6bd2dde4f", 1.0, -1);
-  graph.write_put_edge(context, "Ud5b22ebf52f2", "B310b66ab31fb", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B0e230e9108dd", -1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "Uad577360d968", "Cbce32a9b256a", 3.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "Be29b4af3f7a5", -1.0, -1);
-  graph.write_put_edge(context, "C958e7588ae1c", "U38fdca6685ca", 1.0, -1);
-  graph.write_put_edge(context, "B23b74174e659", "U95f3426b8e5d", 1.0, -1);
-  graph.write_put_edge(context, "U47b466d57da1", "Bad1c69de7837", -3.0, -1);
-  graph.write_put_edge(context, "U016217c34c6e", "Ca0a6aea6c82e", 1.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "B491d307dfe01", 1.0, -1);
-  graph.write_put_edge(context, "U79466f73dc0c", "B9c01ce5718d1", -6.0, -1);
-  graph.write_put_edge(context, "U704bd6ecde75", "C3b855f713d19", 1.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "C0b19d314485e", 4.0, -1);
-  graph.write_put_edge(context, "U1c285703fc63", "Uad577360d968", 1.0, -1);
-  graph.write_put_edge(context, "Ce49159fe9d01", "U6661263fb410", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B8a531802473b", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B310b66ab31fb", 4.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "B491d307dfe01", 1.0, -1);
-  graph.write_put_edge(context, "Ud04c89aaf453", "U8a78048d60f7", 1.0, -1);
-  graph.write_put_edge(context, "U9605bd4d1218", "B5a1c1d3d0140", 2.0, -1);
-  graph.write_put_edge(context, "Ud04c89aaf453", "B73a44e2bbd44", 4.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B9c01ce5718d1", 1.0, -1);
-  graph.write_put_edge(context, "Uc4ebbce44401", "Bed5126bc655d", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B79efabc4d8bf", 1.0, -1);
-  graph.write_put_edge(context, "Be5bb2f3d56cb", "U3c63a9b6115a", 1.0, -1);
-  graph.write_put_edge(context, "U8842ed397bb7", "C89c123f7bcf5", 1.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "B7f628ad203b5", 8.0, -1);
-  graph.write_put_edge(context, "U0f63ee3db59b", "Cc616eded7a99", 1.0, -1);
-  graph.write_put_edge(context, "U26aca0e369c7", "B45d72e29f004", 1.0, -1);
-  graph.write_put_edge(context, "Ubeded808a9c0", "B9c01ce5718d1", 6.0, -1);
-  graph.write_put_edge(context, "B30bf91bf5845", "Ue6cc7bfa0efd", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "Cb95e21215efa", 1.0, -1);
-  graph.write_put_edge(context, "C16dfdd8077c8", "U83282a51b600", 1.0, -1);
-  graph.write_put_edge(context, "C1f41b842849c", "U99a0f1f7e6ee", 1.0, -1);
-  graph.write_put_edge(context, "U1c285703fc63", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B60d725feca77", -1.0, -1);
-  graph.write_put_edge(context, "B3f6f837bc345", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "U704bd6ecde75", "Cfd47f43ac9cf", 1.0, -1);
-  graph.write_put_edge(context, "U4a82930ca419", "C472b59eeafa5", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Ub93799d9400e", 1.0, -1);
-  graph.write_put_edge(context, "B47cc49866c37", "Uf5ee43a1b729", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B491d307dfe01", 3.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "C3fd1fdebe0e9", 1.0, -1);
-  graph.write_put_edge(context, "U0e6659929c53", "C55a114ca6e7c", 1.0, -1);
-  graph.write_put_edge(context, "U7a8d8324441d", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "U638f5c19326f", "C63e21d051dda", 1.0, -1);
-  graph.write_put_edge(context, "U6240251593cd", "B75a44a52fa29", 4.0, -1);
-  graph.write_put_edge(context, "C7986cd8a648a", "U682c3380036f", 1.0, -1);
-  graph.write_put_edge(context, "C637133747308", "Ue202d5b01f8d", 1.0, -1);
-  graph.write_put_edge(context, "U9605bd4d1218", "B9c01ce5718d1", 2.0, -1);
-  graph.write_put_edge(context, "B68247950d9c0", "U9ce5721e93cf", 1.0, -1);
-  graph.write_put_edge(context, "Bf843e315d71b", "Uf6ce05bc4e5a", 1.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "B5a1c1d3d0140", 5.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B5eb4c6be535a", -1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B79efabc4d8bf", 2.0, -1);
-  graph.write_put_edge(context, "B4115d364e05b", "Uf8bf10852d43", 1.0, -1);
-  graph.write_put_edge(context, "Ue40b938f47a4", "B8120aa1edccb", 1.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "B499bfc56e77b", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "Cd172fb3fdc41", 1.0, -1);
-  graph.write_put_edge(context, "Uaa4e2be7a87a", "C0b19d314485e", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "B5eb4c6be535a", -1.0, -1);
-  graph.write_put_edge(context, "Bad1c69de7837", "Uad577360d968", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Bf34ee3bfc12b", 3.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "C2bbd63b00224", 1.0, -1);
-  graph.write_put_edge(context, "U35eb26fc07b4", "Cb117f464e558", -1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Cc42c3eeb9d20", 1.0, -1);
-  graph.write_put_edge(context, "C78ad459d3b81", "U9a2c85753a6d", 1.0, -1);
-  graph.write_put_edge(context, "Uf2b0a6b1d423", "C3fd1fdebe0e9", 7.0, -1);
-  graph.write_put_edge(context, "Uaa4e2be7a87a", "B7f628ad203b5", 9.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Be2b46c17f1da", -1.0, -1);
-  graph.write_put_edge(context, "U83e829a2e822", "Bad1c69de7837", -4.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "C35678a54ef5f", 5.0, -1);
-  graph.write_put_edge(context, "Uf5096f6ab14e", "U7a8d8324441d", 1.0, -1);
-  graph.write_put_edge(context, "C9462ca240ceb", "Uf5096f6ab14e", 1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "C4893c40e481d", -1.0, -1);
-  graph.write_put_edge(context, "U18a178de1dfb", "Bf34ee3bfc12b", 1.0, -1);
-  graph.write_put_edge(context, "Bfae1726e4e87", "Uadeb43da4abb", 1.0, -1);
-  graph.write_put_edge(context, "U3de789cac826", "C3c17b70c3357", 1.0, -1);
-  graph.write_put_edge(context, "U6661263fb410", "Ce49159fe9d01", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B310b66ab31fb", 1.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "C6aebafa4fe8e", 6.0, -1);
-  graph.write_put_edge(context, "U21769235b28d", "C6d52e861b366", 1.0, -1);
-  graph.write_put_edge(context, "Uad577360d968", "C6a2263dc469e", 5.0, -1);
-  graph.write_put_edge(context, "Udece0afd9a8b", "Bad1c69de7837", 9.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "C6aebafa4fe8e", 1.0, -1);
-  graph.write_put_edge(context, "Ueb139752b907", "B1533941e2773", 1.0, -1);
-  graph.write_put_edge(context, "Udece0afd9a8b", "U1c285703fc63", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "Be2b46c17f1da", -1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B92e4a185c654", 1.0, -1);
-  graph.write_put_edge(context, "Cbcf72c7e6061", "U0f63ee3db59b", 1.0, -1);
-  graph.write_put_edge(context, "Cf92f90725ffc", "U6661263fb410", 1.0, -1);
-  graph.write_put_edge(context, "U95f3426b8e5d", "B79efabc4d8bf", 3.0, -1);
-  graph.write_put_edge(context, "U526f361717a8", "B9c01ce5718d1", 0.0, -1);
-  graph.write_put_edge(context, "Ud9df8116deba", "B310b66ab31fb", 1.0, -1);
-  graph.write_put_edge(context, "U6661263fb410", "C22e1102411ce", 1.0, -1);
-  graph.write_put_edge(context, "U21769235b28d", "C8ece5c618ac1", 1.0, -1);
-  graph.write_put_edge(context, "U99a0f1f7e6ee", "B10d3f548efc4", 1.0, -1);
-  graph.write_put_edge(context, "Ce06bda6030fe", "U362d375c067c", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Bf3a0a1165271", -1.0, -1);
-  graph.write_put_edge(context, "C5167c9b3d347", "U362d375c067c", 1.0, -1);
-  graph.write_put_edge(context, "C613f00c1333c", "U80e22da6d8c4", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B0a87a669fc28", 3.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "C588ffef22463", 4.0, -1);
-  graph.write_put_edge(context, "Uc1158424318a", "C9028c7415403", -1.0, -1);
-  graph.write_put_edge(context, "Ue40b938f47a4", "B944097cdd968", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B310b66ab31fb", 1.0, -1);
-  graph.write_put_edge(context, "U016217c34c6e", "U80e22da6d8c4", 1.0, -1);
-  graph.write_put_edge(context, "U362d375c067c", "C5060d0101429", 1.0, -1);
-  graph.write_put_edge(context, "U9a2c85753a6d", "Ce1a7d8996eb0", 2.0, -1);
-  graph.write_put_edge(context, "Uad577360d968", "C399b6349ab02", 6.0, -1);
-  graph.write_put_edge(context, "C992d8370db6b", "U6d2f25cc4264", 1.0, -1);
-  graph.write_put_edge(context, "Uf6ce05bc4e5a", "B9c01ce5718d1", 1.0, -1);
-  graph.write_put_edge(context, "U016217c34c6e", "C15d8dfaceb75", 8.0, -1);
-  graph.write_put_edge(context, "Ub93799d9400e", "B491d307dfe01", 2.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "Cac6ca02355da", 1.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "C4f2dafca724f", 5.0, -1);
-  graph.write_put_edge(context, "U0c17798eaab4", "Uad577360d968", 1.0, -1);
-  graph.write_put_edge(context, "U8842ed397bb7", "C8c753f46c014", 1.0, -1);
-  graph.write_put_edge(context, "U09cf1f359454", "B73a44e2bbd44", 1.0, -1);
-  graph.write_put_edge(context, "U6d2f25cc4264", "C8d80016b8292", 1.0, -1);
-  graph.write_put_edge(context, "C7a807e462b65", "Ud7002ae5a86c", 1.0, -1);
-  graph.write_put_edge(context, "C481cd737c873", "U21769235b28d", 1.0, -1);
-  graph.write_put_edge(context, "Uf3b5141d73f3", "B9c01ce5718d1", -3.0, -1);
-  graph.write_put_edge(context, "U72f88cf28226", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "Bd49e3dac97b0", "Uadeb43da4abb", 1.0, -1);
-  graph.write_put_edge(context, "C0166be581dd4", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "Cd172fb3fdc41", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U79466f73dc0c", "U01814d1ec9ff", 1.0, -1);
-  graph.write_put_edge(context, "U362d375c067c", "C5167c9b3d347", 1.0, -1);
-  graph.write_put_edge(context, "Ue6cc7bfa0efd", "Bed5126bc655d", 7.0, -1);
-  graph.write_put_edge(context, "U8842ed397bb7", "C789dceb76123", 1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "Ccbd85b8513f3", 1.0, -1);
-  graph.write_put_edge(context, "Cf77494dc63d7", "U38fdca6685ca", 1.0, -1);
-  graph.write_put_edge(context, "U9a89e0679dec", "B0e230e9108dd", 1.0, -1);
-  graph.write_put_edge(context, "Cd4417a5d718e", "Ub93799d9400e", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "Ud9df8116deba", 1.0, -1);
-  graph.write_put_edge(context, "Cb14487d862b3", "Uf5096f6ab14e", 1.0, -1);
-  graph.write_put_edge(context, "Uaa4e2be7a87a", "C588ffef22463", 1.0, -1);
-  graph.write_put_edge(context, "U0c17798eaab4", "C588ffef22463", 5.0, -1);
-  graph.write_put_edge(context, "Uaa4e2be7a87a", "C78d6fac93d00", -1.0, -1);
-  graph.write_put_edge(context, "U59abf06369c3", "Be2b46c17f1da", -1.0, -1);
-  graph.write_put_edge(context, "Ucb84c094edba", "B491d307dfe01", 0.0, -1);
-  graph.write_put_edge(context, "Ubeded808a9c0", "B7f628ad203b5", -9.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "Ue7a29d5409f2", 1.0, -1);
-  graph.write_put_edge(context, "U4ba2e4e81c0e", "Caa62fc21e191", 1.0, -1);
-  graph.write_put_edge(context, "Ub93799d9400e", "Ccae34b3da05e", 1.0, -1);
-  graph.write_put_edge(context, "U0e6659929c53", "C6d52e861b366", -1.0, -1);
-  graph.write_put_edge(context, "U38fdca6685ca", "C0f834110f700", 1.0, -1);
-  graph.write_put_edge(context, "B92e4a185c654", "U41784ed376c3", 1.0, -1);
-  graph.write_put_edge(context, "B5a1c1d3d0140", "Uc3c31b8a022f", 1.0, -1);
-  graph.write_put_edge(context, "C6a2263dc469e", "Uf2b0a6b1d423", 1.0, -1);
-  graph.write_put_edge(context, "U9a89e0679dec", "Cbce32a9b256a", 6.0, -1);
-  graph.write_put_edge(context, "Uf5096f6ab14e", "C3e84102071d1", 1.0, -1);
-  graph.write_put_edge(context, "Uef7fbf45ef11", "C94bb73c10a06", 1.0, -1);
-  graph.write_put_edge(context, "C4f2dafca724f", "U7a8d8324441d", 1.0, -1);
-  graph.write_put_edge(context, "U4f530cfe771e", "B7f628ad203b5", 0.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B75a44a52fa29", 1.0, -1);
-  graph.write_put_edge(context, "Ud5f1a29622d1", "B7f628ad203b5", 1.0, -1);
-  graph.write_put_edge(context, "Cbbf2df46955b", "U7a8d8324441d", 1.0, -1);
-  graph.write_put_edge(context, "B5eb4c6be535a", "Uad577360d968", 1.0, -1);
-  graph.write_put_edge(context, "U95f3426b8e5d", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U01814d1ec9ff", "C7062e90f7422", 1.0, -1);
-  graph.write_put_edge(context, "U99a0f1f7e6ee", "C279db553a831", 1.0, -1);
-  graph.write_put_edge(context, "C15d8dfaceb75", "U9e42f6dab85a", 1.0, -1);
-  graph.write_put_edge(context, "Ca0a6aea6c82e", "U016217c34c6e", 1.0, -1);
-  graph.write_put_edge(context, "Uc3c31b8a022f", "B5a1c1d3d0140", 1.0, -1);
-  graph.write_put_edge(context, "U35eb26fc07b4", "B7f628ad203b5", -2.0, -1);
-  graph.write_put_edge(context, "Ue40b938f47a4", "Cb3c476a45037", 1.0, -1);
-  graph.write_put_edge(context, "Uaa4e2be7a87a", "C070e739180d6", 8.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B8a531802473b", -1.0, -1);
-  graph.write_put_edge(context, "U6661263fb410", "Ccb7dc40f1513", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Cb07d467c1c5e", 1.0, -1);
-  graph.write_put_edge(context, "C789dceb76123", "U8842ed397bb7", 1.0, -1);
-  graph.write_put_edge(context, "Uad577360d968", "U389f9f24b31c", 1.0, -1);
-  graph.write_put_edge(context, "C54972a5fbc16", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "Be7bc0cfecab3", "U95f3426b8e5d", 1.0, -1);
-  graph.write_put_edge(context, "Bb78026d99388", "U9a89e0679dec", 1.0, -1);
-  graph.write_put_edge(context, "U389f9f24b31c", "B25c85fe0df2d", 5.0, -1);
-  graph.write_put_edge(context, "U79466f73dc0c", "Bad1c69de7837", 2.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Ba3c4a280657d", 3.0, -1);
-  graph.write_put_edge(context, "C6d52e861b366", "U21769235b28d", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "C6acd550a4ef3", 1.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "B60d725feca77", 1.0, -1);
-  graph.write_put_edge(context, "U1c285703fc63", "B63fbe1427d09", 1.0, -1);
-  graph.write_put_edge(context, "U8aa2e2623fa5", "C7c4d9ca4623e", 1.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "C6d52e861b366", -1.0, -1);
-  graph.write_put_edge(context, "C30e7409c2d5f", "U80e22da6d8c4", 1.0, -1);
-  graph.write_put_edge(context, "Ub01f4ad1b03f", "B491d307dfe01", 1.0, -1);
-  graph.write_put_edge(context, "C801f204d0da8", "U21769235b28d", 1.0, -1);
-  graph.write_put_edge(context, "C5782d559baad", "U0cd6bd2dde4f", 1.0, -1);
-  graph.write_put_edge(context, "U41784ed376c3", "B92e4a185c654", 1.0, -1);
-  graph.write_put_edge(context, "U26aca0e369c7", "Cb117f464e558", 6.0, -1);
-  graph.write_put_edge(context, "U704bd6ecde75", "Cdd49e516723a", 1.0, -1);
-  graph.write_put_edge(context, "Ucbd309d6fcc0", "B5e7178dd70bb", 1.0, -1);
-  graph.write_put_edge(context, "Uf8bf10852d43", "B19d70698e3d8", 1.0, -1);
-  graph.write_put_edge(context, "C5060d0101429", "U362d375c067c", 1.0, -1);
-  graph.write_put_edge(context, "B253177f84f08", "Uf8bf10852d43", 1.0, -1);
-  graph.write_put_edge(context, "U34252014c05b", "Bb1e3630d2f4a", 1.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "Cb14487d862b3", 6.0, -1);
-  graph.write_put_edge(context, "Cc01e00342d63", "U6661263fb410", 1.0, -1);
-  graph.write_put_edge(context, "C10872dc9b863", "U499f24158a40", 1.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "Be29b4af3f7a5", -1.0, -1);
-  graph.write_put_edge(context, "U499f24158a40", "C4818c4ed20bf", 1.0, -1);
-  graph.write_put_edge(context, "C3fd1fdebe0e9", "U7a8d8324441d", 1.0, -1);
-  graph.write_put_edge(context, "U11456af7d414", "Bad1c69de7837", -2.0, -1);
-  graph.write_put_edge(context, "U95f3426b8e5d", "C992d8370db6b", 1.0, -1);
-  graph.write_put_edge(context, "U80e22da6d8c4", "B45d72e29f004", 3.0, -1);
-  graph.write_put_edge(context, "U8a78048d60f7", "B3b3f2ecde430", -1.0, -1);
-  graph.write_put_edge(context, "U1bcba4fd7175", "Bc4addf09b79f", 3.0, -1);
-}
-
-#[test]
-fn encoding_serde() {
-  let in_command: String = "foo".into();
-  let in_context: &str = "bar";
-  let in_arg1: &str = "baz";
-  let in_arg2: &str = "bus";
-
-  let payload = rmp_serde::to_vec(&(
-    in_command.clone(),
-    in_context,
-    rmp_serde::to_vec(&(in_arg1, in_arg2)).unwrap(),
-  ))
-  .unwrap();
-
-  let out_command: &str;
-  let out_context: String;
-  let _out_args: Vec<u8>;
-
-  (out_command, out_context, _out_args) =
-    rmp_serde::from_slice(payload.as_slice()).unwrap();
-
-  assert_eq!(out_command, in_command);
-  assert_eq!(out_context, in_context);
-}
-
-#[test]
-fn encoding_response() {
-  let foo = ("foo".to_string(), 1, 2, 3);
-  let payload = encode_response(&foo).unwrap();
-
-  let bar: (String, i32, i32, i32) = decode_response(&payload).unwrap();
-
-  assert_eq!(foo.0, bar.0);
-  assert_eq!(foo.1, bar.1);
-  assert_eq!(foo.2, bar.2);
-  assert_eq!(foo.3, bar.3);
-}
-
-#[test]
-fn no_assert() {
-  assert_eq!(meritrank_core::constants::ASSERT, false);
-}
-
-#[test]
-fn recalculate_zero_graph_all() {
-  let mut graph = AugMultiGraph::new();
-
-  put_testing_edges(&mut graph, "");
-
-  graph.write_recalculate_zero();
-
-  let res: Vec<_> =
-    graph.read_graph("", "Uadeb43da4abb", "B7f628ad203b5", false, 0, 10000);
-
-  let n = res.len();
-
-  println!("Got {} edges", n);
-
-  assert!(n > 1);
-  assert!(n < 5);
-}
-
-#[test]
-fn recalculate_out_of_bounds_regression() {
-  let mut graph = AugMultiGraph::new();
-
-  graph.write_put_edge("", "U1", "U2", 1.0, -1);
-  graph.write_put_edge("", "U1", "U3", 1.0, -1);
-
-  graph.write_recalculate_zero();
-}
-
-#[test]
-fn graph_sort_order() {
-  let mut graph = AugMultiGraph::new();
-
-  put_testing_edges(&mut graph, "");
-
-  graph.write_recalculate_zero();
-
-  let res: Vec<_> =
-    graph.read_graph("", "Uadeb43da4abb", "Bfae1726e4e87", false, 0, 10000);
-
-  assert!(res.len() > 1);
-
-  for n in 1..res.len() {
-    assert!(res[n - 1].2.abs() >= res[n].2.abs());
-  }
-}
-
-#[test]
-fn recalculate_zero_graph_duplicates() {
-  let mut graph = AugMultiGraph::new();
-
-  put_testing_edges(&mut graph, "");
-
-  graph.write_recalculate_zero();
-
-  let res: Vec<_> =
-    graph.read_graph("", "Bb5f87c1621d5", "Ub01f4ad1b03f", false, 0, 10000);
-
-  assert!(res.len() > 1);
-
-  for (i, x) in res.iter().enumerate() {
-    for (j, y) in res.iter().take(i).enumerate() {
-      if x.0 == y.0 && x.1 == y.1 {
-        println!("Duplicate: [{}, {}] {} -> {}", i, j, x.0, x.1);
-      }
-      assert!(x.0 != y.0 || x.1 != y.1);
-    }
-  }
-}
-
-#[test]
-fn recalculate_zero_graph_positive_only() {
-  let mut graph = AugMultiGraph::new();
-
-  put_testing_edges(&mut graph, "");
-
-  graph.write_recalculate_zero();
-
-  let res: Vec<_> =
-    graph.read_graph("", "Uadeb43da4abb", "B7f628ad203b5", true, 0, 10000);
-
-  let n = res.len();
-
-  println!("Got {} edges", n);
-  assert!(n > 1);
-  assert!(n < 5);
-}
-
-#[test]
-fn recalculate_zero_graph_focus_beacon() {
-  let mut graph = AugMultiGraph::new();
-
-  put_testing_edges(&mut graph, "");
-
-  graph.write_recalculate_zero();
-
-  let res: Vec<_> =
-    graph.read_graph("", "U95f3426b8e5d", "B79efabc4d8bf", true, 0, 10000);
-
-  let n = res.len();
-
-  println!("Got {} edges", n);
-
-  for edge in res {
-    println!("{} -> {}", edge.0, edge.1);
-  }
-
-  assert!(n >= 2);
-  assert!(n < 80);
-}
-
-#[test]
-fn recalculate_zero_reset_perf() {
-  let mut graph = AugMultiGraph::new();
-
-  put_testing_edges(&mut graph, "");
-  graph.write_recalculate_zero();
-  graph.reset();
-  put_testing_edges(&mut graph, "");
-  graph.write_create_context("X");
-  graph.write_create_context("Y");
-  graph.write_create_context("Z");
-  graph.write_recalculate_zero();
-
-  let begin = SystemTime::now();
-  let get_time =
-    || SystemTime::now().duration_since(begin).unwrap().as_millis();
-
-  let res: Vec<_> = graph.read_graph("", "Uadeb43da4abb", "B0e230e9108dd", true, 0, 10000);
-
-  assert!(res.len() > 1);
-
-  assert!(get_time() < 200);
-}
-
-#[test]
-fn recalculate_zero_scores() {
-  let mut graph = AugMultiGraph::new();
-
-  put_testing_edges(&mut graph, "");
-
-  graph.write_recalculate_zero();
-
-  let res: Vec<_> = graph.read_scores(
-    "",
-    "Uadeb43da4abb",
-    "B",
-    true,
-    100.0,
-    false,
-    -100.0,
-    false,
-    0,
-    u32::MAX,
-  );
-
-  let n = res.len();
-
-  println!("Got {} edges", n);
-  assert!(n > 5);
-  assert!(n < 80);
-}
-
-#[test]
-fn scores_sort_order() {
-  let mut graph = AugMultiGraph::new();
-
-  put_testing_edges(&mut graph, "");
-
-  graph.write_recalculate_zero();
-
-  let res: Vec<_> = graph.read_scores(
-    "",
-    "Uadeb43da4abb",
-    "B",
-    true,
-    100.0,
-    false,
-    -100.0,
-    false,
-    0,
-    u32::MAX,
-  );
-
-  assert!(res.len() > 1);
-
-  for n in 1..res.len() {
-    assert!(res[n - 1].2.abs() >= res[n].2.abs());
-  }
+fn put_testing_edges(graph: &mut AugMultiGraph) {
+  graph.write_put_edge("", "U0cd6bd2dde4f", "B7f628ad203b5", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "C070e739180d6", 9.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "Bad1c69de7837", 7.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B92e4a185c654", 3.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B3c467fb437b2", -1.0, -1);
+  graph.write_put_edge("", "U585dfead09c6", "C6d52e861b366", -1.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "C78d6fac93d00", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "Cbbf2df46955b", 1.0, -1);
+  graph.write_put_edge("", "U4f530cfe771e", "B9c01ce5718d1", 0.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Cd6c9d5cba220", 1.0, -1);
+  graph.write_put_edge("", "Cf4b448ef8618", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "Cbbf2df46955b", 4.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B73a44e2bbd44", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B5a1c1d3d0140", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U1df3e39ebe59", "Bea16f01b8cc5", 1.0, -1);
+  graph.write_put_edge("", "Uadeb43da4abb", "Bfae1726e4e87", 1.0, -1);
+  graph.write_put_edge("", "C599f6e6f6b64", "U26aca0e369c7", 1.0, -1);
+  graph.write_put_edge("", "U79466f73dc0c", "B7f628ad203b5", 6.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B3c467fb437b2", -1.0, -1);
+  graph.write_put_edge("", "Ud7002ae5a86c", "B75a44a52fa29", -2.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "C6acd550a4ef3", -1.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "B5eb4c6be535a", 5.0, -1);
+  graph.write_put_edge("", "B9c01ce5718d1", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U99a0f1f7e6ee", "Bd90a1cf73384", 1.0, -1);
+  graph.write_put_edge("", "U0e6659929c53", "Cffd169930956", 1.0, -1);
+  graph.write_put_edge("", "Cd1c25e32ad21", "Ucd424ac24c15", 1.0, -1);
+  graph.write_put_edge("", "Uac897fe92894", "B9c01ce5718d1", -2.0, -1);
+  graph.write_put_edge("", "Bc4addf09b79f", "U0cd6bd2dde4f", 1.0, -1);
+  graph.write_put_edge("", "U638f5c19326f", "B9cade9992fb9", 1.0, -1);
+  graph.write_put_edge("", "U3c63a9b6115a", "Bad1c69de7837", 2.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "C6acd550a4ef3", 6.0, -1);
+  graph.write_put_edge("", "U99a0f1f7e6ee", "C4d1d582c53c3", 1.0, -1);
+  graph.write_put_edge("", "Be2b46c17f1da", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "B5e7178dd70bb", "Ucbd309d6fcc0", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "U1c285703fc63", -1.0, -1);
+  graph.write_put_edge("", "C4893c40e481d", "Udece0afd9a8b", 1.0, -1);
+  graph.write_put_edge("", "U9e42f6dab85a", "B3c467fb437b2", 1.0, -1);
+  graph.write_put_edge("", "Ue70d59cc8e3f", "B9c01ce5718d1", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Bdf39d0e1daf5", -1.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "B70df5dbab8c3", 1.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "B5eb4c6be535a", 1.0, -1);
+  graph.write_put_edge("", "U526f361717a8", "Cee9901f0f22c", 1.0, -1);
+  graph.write_put_edge("", "C2bbd63b00224", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "Cb3c476a45037", "Ue40b938f47a4", 1.0, -1);
+  graph.write_put_edge("", "C22e1102411ce", "U6661263fb410", 1.0, -1);
+  graph.write_put_edge("", "U57b6f30fc663", "Bed5126bc655d", -1.0, -1);
+  graph.write_put_edge("", "U6661263fb410", "Cf92f90725ffc", 1.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "C2bbd63b00224", 8.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "Ba5d64165e5d5", -1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U79466f73dc0c", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B5eb4c6be535a", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B499bfc56e77b", -1.0, -1);
+  graph.write_put_edge("", "U3c63a9b6115a", "Cf92f90725ffc", 1.0, -1);
+  graph.write_put_edge("", "Ud04c89aaf453", "B4f14b223b56d", 1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Udece0afd9a8b", 1.0, -1);
+  graph.write_put_edge("", "U38fdca6685ca", "Cf77494dc63d7", 1.0, -1);
+  graph.write_put_edge("", "U83282a51b600", "Be2b46c17f1da", 0.0, -1);
+  graph.write_put_edge("", "U83e829a2e822", "B7f628ad203b5", 14.0, -1);
+  graph.write_put_edge("", "Bc896788cd2ef", "U1bcba4fd7175", 1.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "C67e4476fda28", 6.0, -1);
+  graph.write_put_edge("", "C9028c7415403", "Udece0afd9a8b", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Uadeb43da4abb", "B0e230e9108dd", 4.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "C264c56d501db", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B73a44e2bbd44", 1.0, -1);
+  graph.write_put_edge("", "Ud982a6dee46f", "Be7145faf15cb", 1.0, -1);
+  graph.write_put_edge("", "B0a87a669fc28", "U34252014c05b", 1.0, -1);
+  graph.write_put_edge("", "U0e6659929c53", "Cb967536095de", 1.0, -1);
+  graph.write_put_edge("", "C0f834110f700", "U38fdca6685ca", 1.0, -1);
+  graph.write_put_edge("", "U72f88cf28226", "Cb11edc3d0bc7", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "C0166be581dd4", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "C6a2263dc469e", 2.0, -1);
+  graph.write_put_edge("", "U526f361717a8", "C52d41a9ad558", 1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Cb76829a425d9", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "Cf4b448ef8618", 1.0, -1);
+  graph.write_put_edge("", "Uadeb43da4abb", "C30e7409c2d5f", 2.0, -1);
+  graph.write_put_edge("", "U05e4396e2382", "B7f628ad203b5", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Cb11edc3d0bc7", 1.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "B1533941e2773", 1.0, -1);
+  graph.write_put_edge("", "B506fff6cfc22", "Ub7f9dfb6a7a5", 1.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "C2bbd63b00224", 9.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "C4f2dafca724f", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Bd7a8bfcf3337", 1.0, -1);
+  graph.write_put_edge("", "C1ccb4354d684", "Ue202d5b01f8d", 1.0, -1);
+  graph.write_put_edge("", "Ud5b22ebf52f2", "Cd6c9d5cba220", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Ba5d64165e5d5", -1.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "C6aebafa4fe8e", 8.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "C588ffef22463", 1.0, -1);
+  graph.write_put_edge("", "Ccae34b3da05e", "Ub93799d9400e", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B9c01ce5718d1", 3.0, -1);
+  graph.write_put_edge("", "Uc35c445325f5", "B75a44a52fa29", 2.0, -1);
+  graph.write_put_edge("", "U362d375c067c", "Ce06bda6030fe", 1.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "Cfdde53c79a2d", 3.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B75a44a52fa29", 1.0, -1);
+  graph.write_put_edge("", "Bb5f87c1621d5", "Ub01f4ad1b03f", 1.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "B3c467fb437b2", 2.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "Udece0afd9a8b", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B63fbe1427d09", -1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "C5782d559baad", 1.0, -1);
+  graph.write_put_edge("", "C3b855f713d19", "U704bd6ecde75", 1.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "Cb76829a425d9", 2.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "Ba3c4a280657d", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "Udece0afd9a8b", -1.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "Bdf39d0e1daf5", 1.0, -1);
+  graph.write_put_edge("", "C588ffef22463", "Uef7fbf45ef11", 1.0, -1);
+  graph.write_put_edge("", "U72f88cf28226", "B3f6f837bc345", 1.0, -1);
+  graph.write_put_edge("", "Ba3c4a280657d", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Bd90a1cf73384", 3.0, -1);
+  graph.write_put_edge("", "U638f5c19326f", "B9c01ce5718d1", 2.0, -1);
+  graph.write_put_edge("", "U83282a51b600", "C9462ca240ceb", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "C54972a5fbc16", 1.0, -1);
+  graph.write_put_edge("", "Ub93799d9400e", "B9c01ce5718d1", 5.0, -1);
+  graph.write_put_edge("", "U9e42f6dab85a", "C15d8dfaceb75", 1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "Be2b46c17f1da", -1.0, -1);
+  graph.write_put_edge("", "B8a531802473b", "U016217c34c6e", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "Bb78026d99388", -11.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "C4893c40e481d", 4.0, -1);
+  graph.write_put_edge("", "Cb11edc3d0bc7", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Bb1e3630d2f4a", 1.0, -1);
+  graph.write_put_edge("", "U0cd6bd2dde4f", "B92e4a185c654", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B45d72e29f004", -1.0, -1);
+  graph.write_put_edge("", "Cab47a458295f", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Ue55b928fa8dd", "Bed5126bc655d", 3.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "U9a89e0679dec", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "C6aebafa4fe8e", "U9a2c85753a6d", 1.0, -1);
+  graph.write_put_edge("", "Ucdffb8ab5145", "Cf8fb8c05c116", 1.0, -1);
+  graph.write_put_edge("", "U0cd6bd2dde4f", "B9c01ce5718d1", 1.0, -1);
+  graph.write_put_edge("", "U59abf06369c3", "Cda989f4b466d", 1.0, -1);
+  graph.write_put_edge("", "B4f00e7813add", "U09cf1f359454", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B75a44a52fa29", 3.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "U0c17798eaab4", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U09cf1f359454", 1.0, -1);
+  graph.write_put_edge("", "U21769235b28d", "C801f204d0da8", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "B3c467fb437b2", 9.0, -1);
+  graph.write_put_edge("", "U43dcf522b4dd", "B3b3f2ecde430", -1.0, -1);
+  graph.write_put_edge("", "C264c56d501db", "U1bcba4fd7175", 1.0, -1);
+  graph.write_put_edge("", "Ua4041a93bdf4", "B9c01ce5718d1", -1.0, -1);
+  graph.write_put_edge("", "Uc3c31b8a022f", "B45d72e29f004", 3.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "C399b6349ab02", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "B3b3f2ecde430", 3.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B5eb4c6be535a", -1.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "Cfdde53c79a2d", 6.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "Uadeb43da4abb", -1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Bdf39d0e1daf5", -1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "Cbbf2df46955b", 5.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "C78ad459d3b81", 4.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B5a1c1d3d0140", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B25c85fe0df2d", -1.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "C6acd550a4ef3", 1.0, -1);
+  graph.write_put_edge("", "B310b66ab31fb", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "C4b2b6fd8fa9a", 1.0, -1);
+  graph.write_put_edge("", "B70df5dbab8c3", "U09cf1f359454", 1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "U09cf1f359454", 1.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "B75a44a52fa29", 1.0, -1);
+  graph.write_put_edge("", "Uadeb43da4abb", "C9462ca240ceb", -1.0, -1);
+  graph.write_put_edge("", "U9a89e0679dec", "Bb78026d99388", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B491d307dfe01", 3.0, -1);
+  graph.write_put_edge("", "C7c4d9ca4623e", "U8aa2e2623fa5", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "C1c86825bd597", 1.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "C357396896bd0", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B4f00e7813add", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "U9e42f6dab85a", 1.0, -1);
+  graph.write_put_edge("", "U1e41b5f3adff", "B310b66ab31fb", 5.0, -1);
+  graph.write_put_edge("", "Cc2b3069cbe5d", "Ub01f4ad1b03f", 1.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "Uadeb43da4abb", 1.0, -1);
+  graph.write_put_edge("", "U59abf06369c3", "B7f628ad203b5", 3.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "B45d72e29f004", -9.0, -1);
+  graph.write_put_edge("", "U05e4396e2382", "Bad1c69de7837", -1.0, -1);
+  graph.write_put_edge("", "Cd795a41fe71d", "U362d375c067c", 1.0, -1);
+  graph.write_put_edge("", "U72f88cf28226", "B310b66ab31fb", 1.0, -1);
+  graph.write_put_edge("", "B4f14b223b56d", "Ud04c89aaf453", 1.0, -1);
+  graph.write_put_edge("", "U1e41b5f3adff", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U83e829a2e822", "B0e230e9108dd", -4.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "C6a2263dc469e", 3.0, -1);
+  graph.write_put_edge("", "C89c123f7bcf5", "U8842ed397bb7", 1.0, -1);
+  graph.write_put_edge("", "U26aca0e369c7", "C4893c40e481d", 2.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Uaa4e2be7a87a", -1.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "C4893c40e481d", -1.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "B3f6f837bc345", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "C25639690ee57", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Ud9df8116deba", 1.0, -1);
+  graph.write_put_edge("", "Ca8ceac412e6f", "U4ba2e4e81c0e", 1.0, -1);
+  graph.write_put_edge("", "Be29b4af3f7a5", "Uc35c445325f5", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "U02fbd7c8df4c", 1.0, -1);
+  graph.write_put_edge("", "Cb07d467c1c5e", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "U8aa2e2623fa5", "B9c01ce5718d1", -2.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B3b3f2ecde430", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Cf4b448ef8618", 2.0, -1);
+  graph.write_put_edge("", "C9a2135edf7ff", "U83282a51b600", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B19ea554faf29", 1.0, -1);
+  graph.write_put_edge("", "Ba5d64165e5d5", "U1e41b5f3adff", 1.0, -1);
+  graph.write_put_edge("", "U9605bd4d1218", "B75a44a52fa29", 4.0, -1);
+  graph.write_put_edge("", "B499bfc56e77b", "Uc1158424318a", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "Cd59e6cd7e104", 1.0, -1);
+  graph.write_put_edge("", "U83e829a2e822", "Be2b46c17f1da", -8.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B45d72e29f004", -1.0, -1);
+  graph.write_put_edge("", "Cb117f464e558", "U26aca0e369c7", 1.0, -1);
+  graph.write_put_edge("", "U4ba2e4e81c0e", "B7f628ad203b5", -2.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "B19ea554faf29", 1.0, -1);
+  graph.write_put_edge("", "Cfd59a206c07d", "U99a0f1f7e6ee", 1.0, -1);
+  graph.write_put_edge("", "C8ece5c618ac1", "U21769235b28d", 1.0, -1);
+  graph.write_put_edge("", "Uadeb43da4abb", "Cc9f863ff681b", 2.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "Cdcddfb230cb5", 5.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "Cc9f863ff681b", 1.0, -1);
+  graph.write_put_edge("", "U26aca0e369c7", "C6acd550a4ef3", 4.0, -1);
+  graph.write_put_edge("", "C8c753f46c014", "U8842ed397bb7", 1.0, -1);
+  graph.write_put_edge("", "C78d6fac93d00", "Uc1158424318a", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "C357396896bd0", 8.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "Cd59e6cd7e104", 3.0, -1);
+  graph.write_put_edge("", "Bf3a0a1165271", "U9a89e0679dec", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B70df5dbab8c3", 1.0, -1);
+  graph.write_put_edge("", "Cb967536095de", "U0e6659929c53", 1.0, -1);
+  graph.write_put_edge("", "C0b19d314485e", "Uaa4e2be7a87a", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "Bc896788cd2ef", -1.0, -1);
+  graph.write_put_edge("", "Uc35c445325f5", "B9c01ce5718d1", 4.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "B9c01ce5718d1", 10.0, -1);
+  graph.write_put_edge("", "C25639690ee57", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U362d375c067c", "Bad1c69de7837", 0.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "C67e4476fda28", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B60d725feca77", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Bfefe4e25c870", 3.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "Cdcddfb230cb5", 4.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "Cb14487d862b3", 1.0, -1);
+  graph.write_put_edge("", "U682c3380036f", "C7986cd8a648a", 1.0, -1);
+  graph.write_put_edge("", "U02fbd7c8df4c", "Bd7a8bfcf3337", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "Cbbf2df46955b", 5.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "U6240251593cd", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "C8d80016b8292", 1.0, -1);
+  graph.write_put_edge("", "Uc35c445325f5", "B8a531802473b", -5.0, -1);
+  graph.write_put_edge("", "U704bd6ecde75", "B9c01ce5718d1", -1.0, -1);
+  graph.write_put_edge("", "U77f496546efa", "B9c01ce5718d1", -1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B7f628ad203b5", -1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B10d3f548efc4", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "Cd06fea6a395f", 9.0, -1);
+  graph.write_put_edge("", "U7cdd7999301e", "B7f628ad203b5", 1.0, -1);
+  graph.write_put_edge("", "U526f361717a8", "Cf40e8fb326bc", 1.0, -1);
+  graph.write_put_edge("", "B944097cdd968", "Ue40b938f47a4", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B3f6f837bc345", 1.0, -1);
+  graph.write_put_edge("", "U6661263fb410", "Cc01e00342d63", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "Cb76829a425d9", -1.0, -1);
+  graph.write_put_edge("", "Ccb7dc40f1513", "U6661263fb410", 1.0, -1);
+  graph.write_put_edge("", "U83282a51b600", "C9a2135edf7ff", 1.0, -1);
+  graph.write_put_edge("", "Cb76829a425d9", "Ue7a29d5409f2", 1.0, -1);
+  graph.write_put_edge("", "B45d72e29f004", "U26aca0e369c7", 1.0, -1);
+  graph.write_put_edge("", "Ue6cc7bfa0efd", "B5e7178dd70bb", -7.0, -1);
+  graph.write_put_edge("", "Uac897fe92894", "Be2b46c17f1da", 2.0, -1);
+  graph.write_put_edge("", "B73a44e2bbd44", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "C399b6349ab02", 5.0, -1);
+  graph.write_put_edge("", "Cfa08a39f9bb9", "Ubebfe0c8fc29", 1.0, -1);
+  graph.write_put_edge("", "Cdcddfb230cb5", "Udece0afd9a8b", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Bb5f87c1621d5", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "C78d6fac93d00", 2.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B3c467fb437b2", -1.0, -1);
+  graph.write_put_edge("", "C0cd490b5fb6a", "Uad577360d968", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "Be2b46c17f1da", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B499bfc56e77b", -1.0, -1);
+  graph.write_put_edge("", "C2cb023b6bcef", "Ucb84c094edba", 1.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "C4e0db8dec53e", 4.0, -1);
+  graph.write_put_edge("", "Cc931cd2de143", "Ud7002ae5a86c", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "C4893c40e481d", 7.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "U016217c34c6e", 1.0, -1);
+  graph.write_put_edge("", "U682c3380036f", "U6240251593cd", 1.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "B4f00e7813add", 1.0, -1);
+  graph.write_put_edge("", "Ud7002ae5a86c", "Cc931cd2de143", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "B79efabc4d8bf", 1.0, -1);
+  graph.write_put_edge("", "U3de789cac826", "B9c01ce5718d1", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "C888c86d096d0", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "C10872dc9b863", 1.0, -1);
+  graph.write_put_edge("", "B0e230e9108dd", "U9a89e0679dec", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "C2e31b4b1658f", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B25c85fe0df2d", -1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "C81f3f954b643", 1.0, -1);
+  graph.write_put_edge("", "C0a576fc389d9", "U1bcba4fd7175", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B3f6f837bc345", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "C6d52e861b366", 3.0, -1);
+  graph.write_put_edge("", "U362d375c067c", "Cd795a41fe71d", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B3b3f2ecde430", -1.0, -1);
+  graph.write_put_edge("", "U585dfead09c6", "B9c01ce5718d1", 2.0, -1);
+  graph.write_put_edge("", "Cfd47f43ac9cf", "U704bd6ecde75", 1.0, -1);
+  graph.write_put_edge("", "U72f88cf28226", "Cd6c9d5cba220", 1.0, -1);
+  graph.write_put_edge("", "Cdd49e516723a", "U704bd6ecde75", 1.0, -1);
+  graph.write_put_edge("", "U26aca0e369c7", "Be2b46c17f1da", 7.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "C588ffef22463", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B3c467fb437b2", -1.0, -1);
+  graph.write_put_edge("", "Bf34ee3bfc12b", "U6240251593cd", 1.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "Bb78026d99388", 9.0, -1);
+  graph.write_put_edge("", "Ue202d5b01f8d", "B9c01ce5718d1", 2.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B310b66ab31fb", 1.0, -1);
+  graph.write_put_edge("", "U35eb26fc07b4", "C90290100a953", 1.0, -1);
+  graph.write_put_edge("", "Cc9f863ff681b", "Uc1158424318a", 1.0, -1);
+  graph.write_put_edge("", "Uf5ee43a1b729", "C9218f86f6286", 1.0, -1);
+  graph.write_put_edge("", "C888c86d096d0", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "Bfefe4e25c870", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "C6f84810d3cd9", 1.0, -1);
+  graph.write_put_edge("", "Cd6c9d5cba220", "Ud5b22ebf52f2", 1.0, -1);
+  graph.write_put_edge("", "U99a0f1f7e6ee", "C96bdee4f11e2", -18.0, -1);
+  graph.write_put_edge("", "U4a82930ca419", "C2d9ab331aed7", 1.0, -1);
+  graph.write_put_edge("", "C4818c4ed20bf", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Ucd424ac24c15", "Cd1c25e32ad21", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "Bad1c69de7837", 2.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Cfdde53c79a2d", 5.0, -1);
+  graph.write_put_edge("", "U5c827d7de115", "B69723edfec8a", 1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "Cd4417a5d718e", 5.0, -1);
+  graph.write_put_edge("", "Ue202d5b01f8d", "C1ccb4354d684", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B9c01ce5718d1", 4.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "Cdcddfb230cb5", 1.0, -1);
+  graph.write_put_edge("", "C81f3f954b643", "U09cf1f359454", 1.0, -1);
+  graph.write_put_edge("", "U02fbd7c8df4c", "B75a44a52fa29", 7.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "C30e7409c2d5f", 4.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Be5bb2f3d56cb", -1.0, -1);
+  graph.write_put_edge("", "B10d3f548efc4", "U99a0f1f7e6ee", 1.0, -1);
+  graph.write_put_edge("", "Uc3c31b8a022f", "B3c467fb437b2", -1.0, -1);
+  graph.write_put_edge("", "C90290100a953", "U35eb26fc07b4", 1.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "B310b66ab31fb", 1.0, -1);
+  graph.write_put_edge("", "U35eb26fc07b4", "Be2b46c17f1da", 0.0, -1);
+  graph.write_put_edge("", "Ccbd85b8513f3", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "Bc896788cd2ef", 1.0, -1);
+  graph.write_put_edge("", "U0cd6bd2dde4f", "C7062e90f7422", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Be2b46c17f1da", -1.0, -1);
+  graph.write_put_edge("", "C4d1d582c53c3", "U99a0f1f7e6ee", 1.0, -1);
+  graph.write_put_edge("", "U59abf06369c3", "Cb117f464e558", -3.0, -1);
+  graph.write_put_edge("", "B491d307dfe01", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "B25c85fe0df2d", "Uef7fbf45ef11", 1.0, -1);
+  graph.write_put_edge("", "Bdf39d0e1daf5", "Uc1158424318a", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "C3e84102071d1", 6.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B63fbe1427d09", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Cd5983133fb67", 1.0, -1);
+  graph.write_put_edge("", "Cc616eded7a99", "U0f63ee3db59b", 1.0, -1);
+  graph.write_put_edge("", "U34252014c05b", "B19ea554faf29", 1.0, -1);
+  graph.write_put_edge("", "U0f63ee3db59b", "B9c01ce5718d1", -4.0, -1);
+  graph.write_put_edge("", "Uf6ce05bc4e5a", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Cbce32a9b256a", 1.0, -1);
+  graph.write_put_edge("", "U9a89e0679dec", "Bf3a0a1165271", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "B63fbe1427d09", -3.0, -1);
+  graph.write_put_edge("", "U0cd6bd2dde4f", "Bc4addf09b79f", 1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "B4f00e7813add", 3.0, -1);
+  graph.write_put_edge("", "U9e42f6dab85a", "Bad1c69de7837", 3.0, -1);
+  graph.write_put_edge("", "U26aca0e369c7", "C599f6e6f6b64", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "Bdf39d0e1daf5", -1.0, -1);
+  graph.write_put_edge("", "Uf8bf10852d43", "B253177f84f08", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "B7f628ad203b5", 1.0, -1);
+  graph.write_put_edge("", "U43dcf522b4dd", "B9c01ce5718d1", 2.0, -1);
+  graph.write_put_edge("", "C13e2a35d917a", "Uf6ce05bc4e5a", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B8a531802473b", -1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "C247501543b60", 1.0, -1);
+  graph.write_put_edge("", "C2e31b4b1658f", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "C94bb73c10a06", "Uef7fbf45ef11", 1.0, -1);
+  graph.write_put_edge("", "C357396896bd0", "Udece0afd9a8b", 1.0, -1);
+  graph.write_put_edge("", "C6acd550a4ef3", "Uc1158424318a", 1.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "C3e84102071d1", 1.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "Bc4addf09b79f", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "Cfe90cbd73eab", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "C30e7409c2d5f", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "Bf3a0a1165271", -1.0, -1);
+  graph.write_put_edge("", "Uadeb43da4abb", "C2bbd63b00224", 7.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Be2b46c17f1da", -1.0, -1);
+  graph.write_put_edge("", "Caa62fc21e191", "U4ba2e4e81c0e", 1.0, -1);
+  graph.write_put_edge("", "U02fbd7c8df4c", "Bad1c69de7837", -5.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "B73a44e2bbd44", 3.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "U9e42f6dab85a", 1.0, -1);
+  graph.write_put_edge("", "Cb95e21215efa", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "B1533941e2773", "U79466f73dc0c", 1.0, -1);
+  graph.write_put_edge("", "U1e41b5f3adff", "Ba5d64165e5d5", 1.0, -1);
+  graph.write_put_edge("", "U682c3380036f", "Bf34ee3bfc12b", 4.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "Uc3c31b8a022f", -1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "U1c285703fc63", 1.0, -1);
+  graph.write_put_edge("", "U9ce5721e93cf", "B68247950d9c0", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "Uc3c31b8a022f", 1.0, -1);
+  graph.write_put_edge("", "U9a89e0679dec", "Cd06fea6a395f", -1.0, -1);
+  graph.write_put_edge("", "U9e42f6dab85a", "C6a2263dc469e", 5.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B0a87a669fc28", 1.0, -1);
+  graph.write_put_edge("", "Cf40e8fb326bc", "U526f361717a8", 1.0, -1);
+  graph.write_put_edge("", "U4ba2e4e81c0e", "Cb117f464e558", 1.0, -1);
+  graph.write_put_edge("", "U95f3426b8e5d", "B9c01ce5718d1", 2.0, -1);
+  graph.write_put_edge("", "C524134905072", "Ucb84c094edba", 1.0, -1);
+  graph.write_put_edge("", "Cd59e6cd7e104", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "U9a89e0679dec", "Cbbf2df46955b", -1.0, -1);
+  graph.write_put_edge("", "Cbe89905f07d3", "Ub01f4ad1b03f", 1.0, -1);
+  graph.write_put_edge("", "Bed5126bc655d", "Uc4ebbce44401", 1.0, -1);
+  graph.write_put_edge("", "U9605bd4d1218", "B8a531802473b", 2.0, -1);
+  graph.write_put_edge("", "Ub93799d9400e", "B73a44e2bbd44", 5.0, -1);
+  graph.write_put_edge("", "Cee9901f0f22c", "U526f361717a8", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Cc2b3069cbe5d", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "B3b3f2ecde430", 1.0, -1);
+  graph.write_put_edge("", "Ubebfe0c8fc29", "Cfa08a39f9bb9", 1.0, -1);
+  graph.write_put_edge("", "U95f3426b8e5d", "Be7bc0cfecab3", 1.0, -1);
+  graph.write_put_edge("", "C6587e913fbbe", "U6661263fb410", 1.0, -1);
+  graph.write_put_edge("", "U0cd6bd2dde4f", "C5782d559baad", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B25c85fe0df2d", -1.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "B8a531802473b", 1.0, -1);
+  graph.write_put_edge("", "Ccc25a77bfa2a", "U77f496546efa", 1.0, -1);
+  graph.write_put_edge("", "U6240251593cd", "Bf34ee3bfc12b", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "C357396896bd0", 1.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "Cb76829a425d9", 8.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "U016217c34c6e", 1.0, -1);
+  graph.write_put_edge("", "Ucdffb8ab5145", "B9c01ce5718d1", 2.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "B75a44a52fa29", 1.0, -1);
+  graph.write_put_edge("", "Cac6ca02355da", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Bc4addf09b79f", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "U389f9f24b31c", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Ud9df8116deba", 1.0, -1);
+  graph.write_put_edge("", "Ucd424ac24c15", "B9c01ce5718d1", 2.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "B9c01ce5718d1", 9.0, -1);
+  graph.write_put_edge("", "U3c63a9b6115a", "B75a44a52fa29", 5.0, -1);
+  graph.write_put_edge("", "Bea16f01b8cc5", "U1df3e39ebe59", 1.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "C3fd1fdebe0e9", 9.0, -1);
+  graph.write_put_edge("", "Cffd169930956", "U0e6659929c53", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "B3b3f2ecde430", -3.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "C4e0db8dec53e", 1.0, -1);
+  graph.write_put_edge("", "U83282a51b600", "B9c01ce5718d1", -1.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "U9e42f6dab85a", -1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Bfefe4e25c870", 4.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "C070e739180d6", 1.0, -1);
+  graph.write_put_edge("", "C8343a6a576ff", "U02fbd7c8df4c", 1.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "C599f6e6f6b64", 2.0, -1);
+  graph.write_put_edge("", "U77f496546efa", "C9462ca240ceb", -1.0, -1);
+  graph.write_put_edge("", "Cc42c3eeb9d20", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "Ce1a7d8996eb0", -1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "B70df5dbab8c3", 2.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "C35678a54ef5f", 1.0, -1);
+  graph.write_put_edge("", "U72f88cf28226", "C7722465c957a", 1.0, -1);
+  graph.write_put_edge("", "U9605bd4d1218", "C801f204d0da8", 3.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B10d3f548efc4", 3.0, -1);
+  graph.write_put_edge("", "U9a89e0679dec", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "Be7145faf15cb", "Ud982a6dee46f", 1.0, -1);
+  graph.write_put_edge("", "Cd06fea6a395f", "Uaa4e2be7a87a", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "C78ad459d3b81", 6.0, -1);
+  graph.write_put_edge("", "Bb1e3630d2f4a", "U34252014c05b", 1.0, -1);
+  graph.write_put_edge("", "U6661263fb410", "B75a44a52fa29", 3.0, -1);
+  graph.write_put_edge("", "Uadeb43da4abb", "Bd49e3dac97b0", 1.0, -1);
+  graph.write_put_edge("", "Ub93799d9400e", "Cd4417a5d718e", 1.0, -1);
+  graph.write_put_edge("", "C399b6349ab02", "Uf2b0a6b1d423", 1.0, -1);
+  graph.write_put_edge("", "B79efabc4d8bf", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U83282a51b600", "C16dfdd8077c8", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "U9a2c85753a6d", 1.0, -1);
+  graph.write_put_edge("", "B19ea554faf29", "U34252014c05b", 1.0, -1);
+  graph.write_put_edge("", "B75a44a52fa29", "U01814d1ec9ff", 1.0, -1);
+  graph.write_put_edge("", "C35678a54ef5f", "Uaa4e2be7a87a", 1.0, -1);
+  graph.write_put_edge("", "Bc173d5552e2e", "U95f3426b8e5d", 1.0, -1);
+  graph.write_put_edge("", "Uc3c31b8a022f", "Bb78026d99388", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "Be5bb2f3d56cb", -1.0, -1);
+  graph.write_put_edge("", "Cb62aea64ea97", "U0e6659929c53", 1.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "B25c85fe0df2d", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B8a531802473b", -1.0, -1);
+  graph.write_put_edge("", "C5127d08eb786", "Ucd424ac24c15", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "Be2b46c17f1da", 5.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "U1c285703fc63", 1.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "C6a2263dc469e", 1.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "B0e230e9108dd", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Uad577360d968", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B4f14b223b56d", -1.0, -1);
+  graph.write_put_edge("", "B3c467fb437b2", "U9e42f6dab85a", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "C30fef1977b4a", 8.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B19ea554faf29", 3.0, -1);
+  graph.write_put_edge("", "U6240251593cd", "B9c01ce5718d1", -4.0, -1);
+  graph.write_put_edge("", "U99a0f1f7e6ee", "C1f41b842849c", 1.0, -1);
+  graph.write_put_edge("", "Uac897fe92894", "Cb117f464e558", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "U0cd6bd2dde4f", 1.0, -1);
+  graph.write_put_edge("", "Ucb84c094edba", "C524134905072", 1.0, -1);
+  graph.write_put_edge("", "B19d70698e3d8", "Uf8bf10852d43", 1.0, -1);
+  graph.write_put_edge("", "Cda989f4b466d", "U59abf06369c3", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B1533941e2773", 3.0, -1);
+  graph.write_put_edge("", "U83e829a2e822", "B5eb4c6be535a", 3.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "Bd7a8bfcf3337", 3.0, -1);
+  graph.write_put_edge("", "Cfdde53c79a2d", "Uef7fbf45ef11", 1.0, -1);
+  graph.write_put_edge("", "Ue6cc7bfa0efd", "B30bf91bf5845", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B3b3f2ecde430", -1.0, -1);
+  graph.write_put_edge("", "C63e21d051dda", "U638f5c19326f", 1.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "C30e7409c2d5f", 9.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "C9028c7415403", 3.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "Bd49e3dac97b0", -1.0, -1);
+  graph.write_put_edge("", "C279db553a831", "U99a0f1f7e6ee", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B45d72e29f004", -1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "B491d307dfe01", -1.0, -1);
+  graph.write_put_edge("", "U99a0f1f7e6ee", "Cfd59a206c07d", 1.0, -1);
+  graph.write_put_edge("", "C52d41a9ad558", "U526f361717a8", 1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Uc3c31b8a022f", -1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "C0a576fc389d9", 1.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "C94bb73c10a06", 3.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Ud5b22ebf52f2", 1.0, -1);
+  graph.write_put_edge("", "Uf8bf10852d43", "B4115d364e05b", 1.0, -1);
+  graph.write_put_edge("", "U57b6f30fc663", "B30bf91bf5845", 1.0, -1);
+  graph.write_put_edge("", "U72f88cf28226", "U6d2f25cc4264", 0.0, -1);
+  graph.write_put_edge("", "U3c63a9b6115a", "Be5bb2f3d56cb", 1.0, -1);
+  graph.write_put_edge("", "C7722465c957a", "U72f88cf28226", 1.0, -1);
+  graph.write_put_edge("", "Ub7f9dfb6a7a5", "B506fff6cfc22", 1.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "C9028c7415403", 1.0, -1);
+  graph.write_put_edge("", "U79466f73dc0c", "B45d72e29f004", 5.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B3f6f837bc345", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B4f14b223b56d", -1.0, -1);
+  graph.write_put_edge("", "U6661263fb410", "C31dac67e313b", 1.0, -1);
+  graph.write_put_edge("", "C55a114ca6e7c", "U0e6659929c53", 1.0, -1);
+  graph.write_put_edge("", "C4b2b6fd8fa9a", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U9e42f6dab85a", "C0b19d314485e", -1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Ba3c4a280657d", 2.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B70df5dbab8c3", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "C30fef1977b4a", 1.0, -1);
+  graph.write_put_edge("", "Uc35c445325f5", "Be29b4af3f7a5", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "B5eb4c6be535a", 1.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "Cdcddfb230cb5", 3.0, -1);
+  graph.write_put_edge("", "U9605bd4d1218", "Bd7a8bfcf3337", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "B9c01ce5718d1", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "B3b3f2ecde430", 9.0, -1);
+  graph.write_put_edge("", "U83282a51b600", "B45d72e29f004", -1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B60d725feca77", -1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "Cd59e6cd7e104", 1.0, -1);
+  graph.write_put_edge("", "U26aca0e369c7", "C9028c7415403", 8.0, -1);
+  graph.write_put_edge("", "B9cade9992fb9", "U638f5c19326f", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B0e230e9108dd", -1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U79466f73dc0c", "Be2b46c17f1da", 4.0, -1);
+  graph.write_put_edge("", "C9218f86f6286", "Uf5ee43a1b729", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Bb78026d99388", -1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "B3b3f2ecde430", 6.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Bd49e3dac97b0", -1.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "C9462ca240ceb", 1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "B0e230e9108dd", -1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "Uf5096f6ab14e", 1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Uf2b0a6b1d423", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Bd90a1cf73384", 1.0, -1);
+  graph.write_put_edge("", "Ucb84c094edba", "C2cb023b6bcef", 1.0, -1);
+  graph.write_put_edge("", "Ubebfe0c8fc29", "Bfefe4e25c870", 3.0, -1);
+  graph.write_put_edge("", "U9e42f6dab85a", "C070e739180d6", 2.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "C6f84810d3cd9", 1.0, -1);
+  graph.write_put_edge("", "U14a3c81256ab", "B9c01ce5718d1", 0.0, -1);
+  graph.write_put_edge("", "Cd5983133fb67", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "U0cd6bd2dde4f", "B75a44a52fa29", 1.0, -1);
+  graph.write_put_edge("", "Ue7a29d5409f2", "Ce1a7d8996eb0", 5.0, -1);
+  graph.write_put_edge("", "Ue40b938f47a4", "B9c01ce5718d1", 0.0, -1);
+  graph.write_put_edge("", "U0e6659929c53", "Cb62aea64ea97", 1.0, -1);
+  graph.write_put_edge("", "C1c86825bd597", "U01814d1ec9ff", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "Bb78026d99388", -1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "Cbce32a9b256a", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "C96bdee4f11e2", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "C4893c40e481d", 3.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "B7f628ad203b5", 7.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "Bad1c69de7837", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "Cdeab5b39cc2a", 1.0, -1);
+  graph.write_put_edge("", "B7f628ad203b5", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "C4893c40e481d", 1.0, -1);
+  graph.write_put_edge("", "C96bdee4f11e2", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B0e230e9108dd", -1.0, -1);
+  graph.write_put_edge("", "U02fbd7c8df4c", "C8343a6a576ff", 1.0, -1);
+  graph.write_put_edge("", "C30fef1977b4a", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "U77f496546efa", "Ccc25a77bfa2a", 1.0, -1);
+  graph.write_put_edge("", "Uf6ce05bc4e5a", "C13e2a35d917a", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Cfe90cbd73eab", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "B3c467fb437b2", 2.0, -1);
+  graph.write_put_edge("", "U9e42f6dab85a", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "Cfdde53c79a2d", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "C94bb73c10a06", 9.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Bb78026d99388", -1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B499bfc56e77b", -1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "Ce1a7d8996eb0", 6.0, -1);
+  graph.write_put_edge("", "C7062e90f7422", "U01814d1ec9ff", 1.0, -1);
+  graph.write_put_edge("", "Cf8fb8c05c116", "Ucdffb8ab5145", 1.0, -1);
+  graph.write_put_edge("", "B60d725feca77", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "C070e739180d6", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "C3e84102071d1", "U016217c34c6e", 1.0, -1);
+  graph.write_put_edge("", "B69723edfec8a", "U5c827d7de115", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "B0e230e9108dd", 3.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "C4e0db8dec53e", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "Cfc639b9aa3e0", 1.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "C0cd490b5fb6a", 1.0, -1);
+  graph.write_put_edge("", "Uc3c31b8a022f", "U1c285703fc63", 1.0, -1);
+  graph.write_put_edge("", "U3c63a9b6115a", "B9c01ce5718d1", 3.0, -1);
+  graph.write_put_edge("", "B3b3f2ecde430", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "U38fdca6685ca", "B9c01ce5718d1", 0.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "C78ad459d3b81", 1.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "C67e4476fda28", -1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U01814d1ec9ff", 1.0, -1);
+  graph.write_put_edge("", "U4ba2e4e81c0e", "Ca8ceac412e6f", 1.0, -1);
+  graph.write_put_edge("", "Cfe90cbd73eab", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U79466f73dc0c", "B1533941e2773", 1.0, -1);
+  graph.write_put_edge("", "C8d80016b8292", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Uf6ce05bc4e5a", "Bf843e315d71b", 1.0, -1);
+  graph.write_put_edge("", "U6661263fb410", "C6587e913fbbe", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Bb1e3630d2f4a", 3.0, -1);
+  graph.write_put_edge("", "Ucd424ac24c15", "C5127d08eb786", 1.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "C4e0db8dec53e", 4.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Bad1c69de7837", -1.0, -1);
+  graph.write_put_edge("", "Ud7002ae5a86c", "C7a807e462b65", 1.0, -1);
+  graph.write_put_edge("", "C3c17b70c3357", "U3de789cac826", 1.0, -1);
+  graph.write_put_edge("", "Bd90a1cf73384", "U99a0f1f7e6ee", 1.0, -1);
+  graph.write_put_edge("", "U83282a51b600", "B7f628ad203b5", 1.0, -1);
+  graph.write_put_edge("", "U26aca0e369c7", "Cb117f464e558", 1.0, -1);
+  graph.write_put_edge("", "Ce1a7d8996eb0", "Uf5096f6ab14e", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "Bad1c69de7837", -1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B25c85fe0df2d", -1.0, -1);
+  graph.write_put_edge("", "U95f3426b8e5d", "Bc173d5552e2e", 1.0, -1);
+  graph.write_put_edge("", "U9a89e0679dec", "C6aebafa4fe8e", 8.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "B8a531802473b", 8.0, -1);
+  graph.write_put_edge("", "Ub93799d9400e", "B75a44a52fa29", 5.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Bf34ee3bfc12b", 1.0, -1);
+  graph.write_put_edge("", "U34252014c05b", "B0a87a669fc28", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Cbe89905f07d3", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "Ce1a7d8996eb0", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B4f00e7813add", 1.0, -1);
+  graph.write_put_edge("", "Bd7a8bfcf3337", "U02fbd7c8df4c", 1.0, -1);
+  graph.write_put_edge("", "C2d9ab331aed7", "U4a82930ca419", 1.0, -1);
+  graph.write_put_edge("", "C247501543b60", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "Cfdde53c79a2d", 4.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "C613f00c1333c", 1.0, -1);
+  graph.write_put_edge("", "C31dac67e313b", "U6661263fb410", 1.0, -1);
+  graph.write_put_edge("", "C67e4476fda28", "U1c285703fc63", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "C3e84102071d1", 4.0, -1);
+  graph.write_put_edge("", "U9605bd4d1218", "Cab47a458295f", 3.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "C992d8370db6b", 1.0, -1);
+  graph.write_put_edge("", "Cbce32a9b256a", "U389f9f24b31c", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B63fbe1427d09", -1.0, -1);
+  graph.write_put_edge("", "B63fbe1427d09", "U1c285703fc63", 1.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "B60d725feca77", 8.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "Bfefe4e25c870", 5.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B9c01ce5718d1", 2.0, -1);
+  graph.write_put_edge("", "Uac897fe92894", "B7f628ad203b5", 1.0, -1);
+  graph.write_put_edge("", "B8120aa1edccb", "Ue40b938f47a4", 1.0, -1);
+  graph.write_put_edge("", "Ueb139752b907", "U79466f73dc0c", 1.0, -1);
+  graph.write_put_edge("", "U0e6659929c53", "B9c01ce5718d1", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B491d307dfe01", 2.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "B73a44e2bbd44", 1.0, -1);
+  graph.write_put_edge("", "U38fdca6685ca", "C958e7588ae1c", 1.0, -1);
+  graph.write_put_edge("", "U35eb26fc07b4", "B60d725feca77", 1.0, -1);
+  graph.write_put_edge("", "Cdeab5b39cc2a", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U0f63ee3db59b", "Cbcf72c7e6061", 1.0, -1);
+  graph.write_put_edge("", "C4e0db8dec53e", "U0c17798eaab4", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B7f628ad203b5", -1.0, -1);
+  graph.write_put_edge("", "C472b59eeafa5", "U4a82930ca419", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "C247501543b60", 1.0, -1);
+  graph.write_put_edge("", "Cfc639b9aa3e0", "U389f9f24b31c", 1.0, -1);
+  graph.write_put_edge("", "U95f3426b8e5d", "B23b74174e659", 1.0, -1);
+  graph.write_put_edge("", "U99deecf5a281", "B9c01ce5718d1", 1.0, -1);
+  graph.write_put_edge("", "Bfefe4e25c870", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Ua12e78308f49", "B75a44a52fa29", 4.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "Cd06fea6a395f", 1.0, -1);
+  graph.write_put_edge("", "U682c3380036f", "B75a44a52fa29", 2.0, -1);
+  graph.write_put_edge("", "Ue202d5b01f8d", "C637133747308", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Cab47a458295f", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "Cd06fea6a395f", 8.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Bd7a8bfcf3337", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "U01814d1ec9ff", 1.0, -1);
+  graph.write_put_edge("", "Uf5ee43a1b729", "B47cc49866c37", 1.0, -1);
+  graph.write_put_edge("", "Uac897fe92894", "C9462ca240ceb", 0.0, -1);
+  graph.write_put_edge("", "U21769235b28d", "C481cd737c873", 1.0, -1);
+  graph.write_put_edge("", "C6f84810d3cd9", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Uc3c31b8a022f", "C78d6fac93d00", 3.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "C4f2dafca724f", 8.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "B0e230e9108dd", 2.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Bb78026d99388", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Cdcddfb230cb5", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "U0cd6bd2dde4f", 1.0, -1);
+  graph.write_put_edge("", "Ud5b22ebf52f2", "B310b66ab31fb", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B0e230e9108dd", -1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "Cbce32a9b256a", 3.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "Be29b4af3f7a5", -1.0, -1);
+  graph.write_put_edge("", "C958e7588ae1c", "U38fdca6685ca", 1.0, -1);
+  graph.write_put_edge("", "B23b74174e659", "U95f3426b8e5d", 1.0, -1);
+  graph.write_put_edge("", "U47b466d57da1", "Bad1c69de7837", -3.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "Ca0a6aea6c82e", 1.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "B491d307dfe01", 1.0, -1);
+  graph.write_put_edge("", "U79466f73dc0c", "B9c01ce5718d1", -6.0, -1);
+  graph.write_put_edge("", "U704bd6ecde75", "C3b855f713d19", 1.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "C0b19d314485e", 4.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "Uad577360d968", 1.0, -1);
+  graph.write_put_edge("", "Ce49159fe9d01", "U6661263fb410", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B8a531802473b", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B310b66ab31fb", 4.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "B491d307dfe01", 1.0, -1);
+  graph.write_put_edge("", "Ud04c89aaf453", "U8a78048d60f7", 1.0, -1);
+  graph.write_put_edge("", "U9605bd4d1218", "B5a1c1d3d0140", 2.0, -1);
+  graph.write_put_edge("", "Ud04c89aaf453", "B73a44e2bbd44", 4.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B9c01ce5718d1", 1.0, -1);
+  graph.write_put_edge("", "Uc4ebbce44401", "Bed5126bc655d", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B79efabc4d8bf", 1.0, -1);
+  graph.write_put_edge("", "Be5bb2f3d56cb", "U3c63a9b6115a", 1.0, -1);
+  graph.write_put_edge("", "U8842ed397bb7", "C89c123f7bcf5", 1.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "B7f628ad203b5", 8.0, -1);
+  graph.write_put_edge("", "U0f63ee3db59b", "Cc616eded7a99", 1.0, -1);
+  graph.write_put_edge("", "U26aca0e369c7", "B45d72e29f004", 1.0, -1);
+  graph.write_put_edge("", "Ubeded808a9c0", "B9c01ce5718d1", 6.0, -1);
+  graph.write_put_edge("", "B30bf91bf5845", "Ue6cc7bfa0efd", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "Cb95e21215efa", 1.0, -1);
+  graph.write_put_edge("", "C16dfdd8077c8", "U83282a51b600", 1.0, -1);
+  graph.write_put_edge("", "C1f41b842849c", "U99a0f1f7e6ee", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B60d725feca77", -1.0, -1);
+  graph.write_put_edge("", "B3f6f837bc345", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U704bd6ecde75", "Cfd47f43ac9cf", 1.0, -1);
+  graph.write_put_edge("", "U4a82930ca419", "C472b59eeafa5", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Ub93799d9400e", 1.0, -1);
+  graph.write_put_edge("", "B47cc49866c37", "Uf5ee43a1b729", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B491d307dfe01", 3.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "C3fd1fdebe0e9", 1.0, -1);
+  graph.write_put_edge("", "U0e6659929c53", "C55a114ca6e7c", 1.0, -1);
+  graph.write_put_edge("", "U7a8d8324441d", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "U638f5c19326f", "C63e21d051dda", 1.0, -1);
+  graph.write_put_edge("", "U6240251593cd", "B75a44a52fa29", 4.0, -1);
+  graph.write_put_edge("", "C7986cd8a648a", "U682c3380036f", 1.0, -1);
+  graph.write_put_edge("", "C637133747308", "Ue202d5b01f8d", 1.0, -1);
+  graph.write_put_edge("", "U9605bd4d1218", "B9c01ce5718d1", 2.0, -1);
+  graph.write_put_edge("", "B68247950d9c0", "U9ce5721e93cf", 1.0, -1);
+  graph.write_put_edge("", "Bf843e315d71b", "Uf6ce05bc4e5a", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "B5a1c1d3d0140", 5.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B5eb4c6be535a", -1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B79efabc4d8bf", 2.0, -1);
+  graph.write_put_edge("", "B4115d364e05b", "Uf8bf10852d43", 1.0, -1);
+  graph.write_put_edge("", "Ue40b938f47a4", "B8120aa1edccb", 1.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "B499bfc56e77b", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "Cd172fb3fdc41", 1.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "C0b19d314485e", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "B5eb4c6be535a", -1.0, -1);
+  graph.write_put_edge("", "Bad1c69de7837", "Uad577360d968", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Bf34ee3bfc12b", 3.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "C2bbd63b00224", 1.0, -1);
+  graph.write_put_edge("", "U35eb26fc07b4", "Cb117f464e558", -1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Cc42c3eeb9d20", 1.0, -1);
+  graph.write_put_edge("", "C78ad459d3b81", "U9a2c85753a6d", 1.0, -1);
+  graph.write_put_edge("", "Uf2b0a6b1d423", "C3fd1fdebe0e9", 7.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "B7f628ad203b5", 9.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Be2b46c17f1da", -1.0, -1);
+  graph.write_put_edge("", "U83e829a2e822", "Bad1c69de7837", -4.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "C35678a54ef5f", 5.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "C9462ca240ceb", "Uf5096f6ab14e", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "C4893c40e481d", -1.0, -1);
+  graph.write_put_edge("", "U18a178de1dfb", "Bf34ee3bfc12b", 1.0, -1);
+  graph.write_put_edge("", "Bfae1726e4e87", "Uadeb43da4abb", 1.0, -1);
+  graph.write_put_edge("", "U3de789cac826", "C3c17b70c3357", 1.0, -1);
+  graph.write_put_edge("", "U6661263fb410", "Ce49159fe9d01", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B310b66ab31fb", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "C6aebafa4fe8e", 6.0, -1);
+  graph.write_put_edge("", "U21769235b28d", "C6d52e861b366", 1.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "C6a2263dc469e", 5.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "Bad1c69de7837", 9.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "C6aebafa4fe8e", 1.0, -1);
+  graph.write_put_edge("", "Ueb139752b907", "B1533941e2773", 1.0, -1);
+  graph.write_put_edge("", "Udece0afd9a8b", "U1c285703fc63", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "Be2b46c17f1da", -1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B92e4a185c654", 1.0, -1);
+  graph.write_put_edge("", "Cbcf72c7e6061", "U0f63ee3db59b", 1.0, -1);
+  graph.write_put_edge("", "Cf92f90725ffc", "U6661263fb410", 1.0, -1);
+  graph.write_put_edge("", "U95f3426b8e5d", "B79efabc4d8bf", 3.0, -1);
+  graph.write_put_edge("", "U526f361717a8", "B9c01ce5718d1", 0.0, -1);
+  graph.write_put_edge("", "Ud9df8116deba", "B310b66ab31fb", 1.0, -1);
+  graph.write_put_edge("", "U6661263fb410", "C22e1102411ce", 1.0, -1);
+  graph.write_put_edge("", "U21769235b28d", "C8ece5c618ac1", 1.0, -1);
+  graph.write_put_edge("", "U99a0f1f7e6ee", "B10d3f548efc4", 1.0, -1);
+  graph.write_put_edge("", "Ce06bda6030fe", "U362d375c067c", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Bf3a0a1165271", -1.0, -1);
+  graph.write_put_edge("", "C5167c9b3d347", "U362d375c067c", 1.0, -1);
+  graph.write_put_edge("", "C613f00c1333c", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B0a87a669fc28", 3.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "C588ffef22463", 4.0, -1);
+  graph.write_put_edge("", "Uc1158424318a", "C9028c7415403", -1.0, -1);
+  graph.write_put_edge("", "Ue40b938f47a4", "B944097cdd968", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B310b66ab31fb", 1.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "U362d375c067c", "C5060d0101429", 1.0, -1);
+  graph.write_put_edge("", "U9a2c85753a6d", "Ce1a7d8996eb0", 2.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "C399b6349ab02", 6.0, -1);
+  graph.write_put_edge("", "C992d8370db6b", "U6d2f25cc4264", 1.0, -1);
+  graph.write_put_edge("", "Uf6ce05bc4e5a", "B9c01ce5718d1", 1.0, -1);
+  graph.write_put_edge("", "U016217c34c6e", "C15d8dfaceb75", 8.0, -1);
+  graph.write_put_edge("", "Ub93799d9400e", "B491d307dfe01", 2.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "Cac6ca02355da", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "C4f2dafca724f", 5.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "Uad577360d968", 1.0, -1);
+  graph.write_put_edge("", "U8842ed397bb7", "C8c753f46c014", 1.0, -1);
+  graph.write_put_edge("", "U09cf1f359454", "B73a44e2bbd44", 1.0, -1);
+  graph.write_put_edge("", "U6d2f25cc4264", "C8d80016b8292", 1.0, -1);
+  graph.write_put_edge("", "C7a807e462b65", "Ud7002ae5a86c", 1.0, -1);
+  graph.write_put_edge("", "C481cd737c873", "U21769235b28d", 1.0, -1);
+  graph.write_put_edge("", "Uf3b5141d73f3", "B9c01ce5718d1", -3.0, -1);
+  graph.write_put_edge("", "U72f88cf28226", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Bd49e3dac97b0", "Uadeb43da4abb", 1.0, -1);
+  graph.write_put_edge("", "C0166be581dd4", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Cd172fb3fdc41", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U79466f73dc0c", "U01814d1ec9ff", 1.0, -1);
+  graph.write_put_edge("", "U362d375c067c", "C5167c9b3d347", 1.0, -1);
+  graph.write_put_edge("", "Ue6cc7bfa0efd", "Bed5126bc655d", 7.0, -1);
+  graph.write_put_edge("", "U8842ed397bb7", "C789dceb76123", 1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "Ccbd85b8513f3", 1.0, -1);
+  graph.write_put_edge("", "Cf77494dc63d7", "U38fdca6685ca", 1.0, -1);
+  graph.write_put_edge("", "U9a89e0679dec", "B0e230e9108dd", 1.0, -1);
+  graph.write_put_edge("", "Cd4417a5d718e", "Ub93799d9400e", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "Ud9df8116deba", 1.0, -1);
+  graph.write_put_edge("", "Cb14487d862b3", "Uf5096f6ab14e", 1.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "C588ffef22463", 1.0, -1);
+  graph.write_put_edge("", "U0c17798eaab4", "C588ffef22463", 5.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "C78d6fac93d00", -1.0, -1);
+  graph.write_put_edge("", "U59abf06369c3", "Be2b46c17f1da", -1.0, -1);
+  graph.write_put_edge("", "Ucb84c094edba", "B491d307dfe01", 0.0, -1);
+  graph.write_put_edge("", "Ubeded808a9c0", "B7f628ad203b5", -9.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "Ue7a29d5409f2", 1.0, -1);
+  graph.write_put_edge("", "U4ba2e4e81c0e", "Caa62fc21e191", 1.0, -1);
+  graph.write_put_edge("", "Ub93799d9400e", "Ccae34b3da05e", 1.0, -1);
+  graph.write_put_edge("", "U0e6659929c53", "C6d52e861b366", -1.0, -1);
+  graph.write_put_edge("", "U38fdca6685ca", "C0f834110f700", 1.0, -1);
+  graph.write_put_edge("", "B92e4a185c654", "U41784ed376c3", 1.0, -1);
+  graph.write_put_edge("", "B5a1c1d3d0140", "Uc3c31b8a022f", 1.0, -1);
+  graph.write_put_edge("", "C6a2263dc469e", "Uf2b0a6b1d423", 1.0, -1);
+  graph.write_put_edge("", "U9a89e0679dec", "Cbce32a9b256a", 6.0, -1);
+  graph.write_put_edge("", "Uf5096f6ab14e", "C3e84102071d1", 1.0, -1);
+  graph.write_put_edge("", "Uef7fbf45ef11", "C94bb73c10a06", 1.0, -1);
+  graph.write_put_edge("", "C4f2dafca724f", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "U4f530cfe771e", "B7f628ad203b5", 0.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B75a44a52fa29", 1.0, -1);
+  graph.write_put_edge("", "Ud5f1a29622d1", "B7f628ad203b5", 1.0, -1);
+  graph.write_put_edge("", "Cbbf2df46955b", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "B5eb4c6be535a", "Uad577360d968", 1.0, -1);
+  graph.write_put_edge("", "U95f3426b8e5d", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U01814d1ec9ff", "C7062e90f7422", 1.0, -1);
+  graph.write_put_edge("", "U99a0f1f7e6ee", "C279db553a831", 1.0, -1);
+  graph.write_put_edge("", "C15d8dfaceb75", "U9e42f6dab85a", 1.0, -1);
+  graph.write_put_edge("", "Ca0a6aea6c82e", "U016217c34c6e", 1.0, -1);
+  graph.write_put_edge("", "Uc3c31b8a022f", "B5a1c1d3d0140", 1.0, -1);
+  graph.write_put_edge("", "U35eb26fc07b4", "B7f628ad203b5", -2.0, -1);
+  graph.write_put_edge("", "Ue40b938f47a4", "Cb3c476a45037", 1.0, -1);
+  graph.write_put_edge("", "Uaa4e2be7a87a", "C070e739180d6", 8.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B8a531802473b", -1.0, -1);
+  graph.write_put_edge("", "U6661263fb410", "Ccb7dc40f1513", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Cb07d467c1c5e", 1.0, -1);
+  graph.write_put_edge("", "C789dceb76123", "U8842ed397bb7", 1.0, -1);
+  graph.write_put_edge("", "Uad577360d968", "U389f9f24b31c", 1.0, -1);
+  graph.write_put_edge("", "C54972a5fbc16", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "Be7bc0cfecab3", "U95f3426b8e5d", 1.0, -1);
+  graph.write_put_edge("", "Bb78026d99388", "U9a89e0679dec", 1.0, -1);
+  graph.write_put_edge("", "U389f9f24b31c", "B25c85fe0df2d", 5.0, -1);
+  graph.write_put_edge("", "U79466f73dc0c", "Bad1c69de7837", 2.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Ba3c4a280657d", 3.0, -1);
+  graph.write_put_edge("", "C6d52e861b366", "U21769235b28d", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "C6acd550a4ef3", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "B60d725feca77", 1.0, -1);
+  graph.write_put_edge("", "U1c285703fc63", "B63fbe1427d09", 1.0, -1);
+  graph.write_put_edge("", "U8aa2e2623fa5", "C7c4d9ca4623e", 1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "C6d52e861b366", -1.0, -1);
+  graph.write_put_edge("", "C30e7409c2d5f", "U80e22da6d8c4", 1.0, -1);
+  graph.write_put_edge("", "Ub01f4ad1b03f", "B491d307dfe01", 1.0, -1);
+  graph.write_put_edge("", "C801f204d0da8", "U21769235b28d", 1.0, -1);
+  graph.write_put_edge("", "C5782d559baad", "U0cd6bd2dde4f", 1.0, -1);
+  graph.write_put_edge("", "U41784ed376c3", "B92e4a185c654", 1.0, -1);
+  graph.write_put_edge("", "U26aca0e369c7", "Cb117f464e558", 6.0, -1);
+  graph.write_put_edge("", "U704bd6ecde75", "Cdd49e516723a", 1.0, -1);
+  graph.write_put_edge("", "Ucbd309d6fcc0", "B5e7178dd70bb", 1.0, -1);
+  graph.write_put_edge("", "Uf8bf10852d43", "B19d70698e3d8", 1.0, -1);
+  graph.write_put_edge("", "C5060d0101429", "U362d375c067c", 1.0, -1);
+  graph.write_put_edge("", "B253177f84f08", "Uf8bf10852d43", 1.0, -1);
+  graph.write_put_edge("", "U34252014c05b", "Bb1e3630d2f4a", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "Cb14487d862b3", 6.0, -1);
+  graph.write_put_edge("", "Cc01e00342d63", "U6661263fb410", 1.0, -1);
+  graph.write_put_edge("", "C10872dc9b863", "U499f24158a40", 1.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "Be29b4af3f7a5", -1.0, -1);
+  graph.write_put_edge("", "U499f24158a40", "C4818c4ed20bf", 1.0, -1);
+  graph.write_put_edge("", "C3fd1fdebe0e9", "U7a8d8324441d", 1.0, -1);
+  graph.write_put_edge("", "U11456af7d414", "Bad1c69de7837", -2.0, -1);
+  graph.write_put_edge("", "U95f3426b8e5d", "C992d8370db6b", 1.0, -1);
+  graph.write_put_edge("", "U80e22da6d8c4", "B45d72e29f004", 3.0, -1);
+  graph.write_put_edge("", "U8a78048d60f7", "B3b3f2ecde430", -1.0, -1);
+  graph.write_put_edge("", "U1bcba4fd7175", "Bc4addf09b79f", 3.0, -1);
 }
 
 fn put_testing_edges_2(graph : &mut AugMultiGraph) {
@@ -1231,6 +994,240 @@ fn put_testing_edges_2(graph : &mut AugMultiGraph) {
   graph.write_put_edge("", "U0ae9f5d0bf02", "Bed48703df71d", 1.0, -1);
   graph.write_put_edge("", "Uf82dbb4708ba", "B91796a98a225", 1.0, -1);
   graph.write_put_edge("", "Ub01f4ad1b03f", "Bca63d8a2057b", 1.0, -1);
+}
+
+#[test]
+fn encoding_serde() {
+  let in_command: String = "foo".into();
+  let in_context: &str = "bar";
+  let in_arg1: &str = "baz";
+  let in_arg2: &str = "bus";
+
+  let payload = rmp_serde::to_vec(&(
+    in_command.clone(),
+    in_context,
+    rmp_serde::to_vec(&(in_arg1, in_arg2)).unwrap(),
+  ))
+  .unwrap();
+
+  let out_command: &str;
+  let out_context: String;
+  let _out_args: Vec<u8>;
+
+  (out_command, out_context, _out_args) =
+    rmp_serde::from_slice(payload.as_slice()).unwrap();
+
+  assert_eq!(out_command, in_command);
+  assert_eq!(out_context, in_context);
+}
+
+#[test]
+fn encoding_response() {
+  let foo = ("foo".to_string(), 1, 2, 3);
+  let payload = encode_response(&foo).unwrap();
+
+  let bar: (String, i32, i32, i32) = decode_response(&payload).unwrap();
+
+  assert_eq!(foo.0, bar.0);
+  assert_eq!(foo.1, bar.1);
+  assert_eq!(foo.2, bar.2);
+  assert_eq!(foo.3, bar.3);
+}
+
+#[test]
+fn no_assert() {
+  assert_eq!(meritrank_core::constants::ASSERT, false);
+}
+
+#[test]
+fn recalculate_zero_graph_all() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges(&mut graph);
+
+  graph.write_recalculate_zero();
+
+  let res: Vec<_> =
+    graph.read_graph("", "Uadeb43da4abb", "B7f628ad203b5", false, 0, 10000);
+
+  let n = res.len();
+
+  println!("Got {} edges", n);
+
+  assert!(n > 1);
+  assert!(n < 5);
+}
+
+#[test]
+fn recalculate_out_of_bounds_regression() {
+  let mut graph = AugMultiGraph::new();
+
+  graph.write_put_edge("", "U1", "U2", 1.0, -1);
+  graph.write_put_edge("", "U1", "U3", 1.0, -1);
+
+  graph.write_recalculate_zero();
+}
+
+#[test]
+fn graph_sort_order() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges(&mut graph);
+
+  graph.write_recalculate_zero();
+
+  let res: Vec<_> =
+    graph.read_graph("", "Uadeb43da4abb", "Bfae1726e4e87", false, 0, 10000);
+
+  assert!(res.len() > 1);
+
+  for n in 1..res.len() {
+    assert!(res[n - 1].2.abs() >= res[n].2.abs());
+  }
+}
+
+#[test]
+fn recalculate_zero_graph_duplicates() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges(&mut graph);
+
+  graph.write_recalculate_zero();
+
+  let res: Vec<_> =
+    graph.read_graph("", "Bb5f87c1621d5", "Ub01f4ad1b03f", false, 0, 10000);
+
+  assert!(res.len() > 1);
+
+  for (i, x) in res.iter().enumerate() {
+    for (j, y) in res.iter().take(i).enumerate() {
+      if x.0 == y.0 && x.1 == y.1 {
+        println!("Duplicate: [{}, {}] {} -> {}", i, j, x.0, x.1);
+      }
+      assert!(x.0 != y.0 || x.1 != y.1);
+    }
+  }
+}
+
+#[test]
+fn recalculate_zero_graph_positive_only() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges(&mut graph);
+
+  graph.write_recalculate_zero();
+
+  let res: Vec<_> =
+    graph.read_graph("", "Uadeb43da4abb", "B7f628ad203b5", true, 0, 10000);
+
+  let n = res.len();
+
+  println!("Got {} edges", n);
+  assert!(n > 1);
+  assert!(n < 5);
+}
+
+#[test]
+fn recalculate_zero_graph_focus_beacon() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges(&mut graph);
+
+  graph.write_recalculate_zero();
+
+  let res: Vec<_> =
+    graph.read_graph("", "U95f3426b8e5d", "B79efabc4d8bf", true, 0, 10000);
+
+  let n = res.len();
+
+  println!("Got {} edges", n);
+
+  for edge in res {
+    println!("{} -> {}", edge.0, edge.1);
+  }
+
+  assert!(n >= 2);
+  assert!(n < 80);
+}
+
+#[test]
+fn recalculate_zero_reset_perf() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges(&mut graph);
+  graph.write_recalculate_zero();
+  graph.reset();
+  put_testing_edges(&mut graph);
+  graph.write_create_context("X");
+  graph.write_create_context("Y");
+  graph.write_create_context("Z");
+  graph.write_recalculate_zero();
+
+  let begin = SystemTime::now();
+  let get_time =
+    || SystemTime::now().duration_since(begin).unwrap().as_millis();
+
+  let res: Vec<_> = graph.read_graph("", "Uadeb43da4abb", "B0e230e9108dd", true, 0, 10000);
+
+  assert!(res.len() > 1);
+
+  assert!(get_time() < 200);
+}
+
+#[test]
+fn recalculate_zero_scores() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges(&mut graph);
+
+  graph.write_recalculate_zero();
+
+  let res: Vec<_> = graph.read_scores(
+    "",
+    "Uadeb43da4abb",
+    "B",
+    true,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
+
+  let n = res.len();
+
+  println!("Got {} edges", n);
+  assert!(n > 5);
+  assert!(n < 80);
+}
+
+#[test]
+fn scores_sort_order() {
+  let mut graph = AugMultiGraph::new();
+
+  put_testing_edges(&mut graph);
+
+  graph.write_recalculate_zero();
+
+  let res: Vec<_> = graph.read_scores(
+    "",
+    "Uadeb43da4abb",
+    "B",
+    true,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
+
+  assert!(res.len() > 1);
+
+  for n in 1..res.len() {
+    assert!(res[n - 1].2.abs() >= res[n].2.abs());
+  }
 }
 
 #[test]
@@ -2276,10 +2273,8 @@ fn mutual_scores_cluster_single_score_uncontexted() {
   println!("{:?}", res);
 
   assert_eq!(res.len(), 2);
-  assert!(res[0].4 > 0.99);
-  assert!(res[0].4 <= 1.0);
-  assert!(res[1].4 >= 0.0);
-  assert!(res[1].4 < 0.01);
+  assert!(res[0].4 == 5);
+  assert!(res[1].4 == 1);
 }
 
 #[test]
@@ -2293,10 +2288,8 @@ fn mutual_scores_cluster_single_score_contexted() {
   println!("{:?}", res);
 
   assert_eq!(res.len(), 2);
-  assert!(res[0].4 > 0.99);
-  assert!(res[0].4 <= 1.0);
-  assert!(res[1].4 >= 0.0);
-  assert!(res[1].4 < 0.01);
+  assert!(res[0].4 == 5);
+  assert!(res[1].4 == 1);
 }
 
 #[test]
@@ -2346,11 +2339,42 @@ fn mutual_scores_clustering() {
     cluster_of_src,
   ) in res.iter()
   {
-    assert!(*cluster_of_dst >= 0.0);
-    assert!(*cluster_of_dst <= 1.0);
-    assert!(*cluster_of_src >= 0.0);
-    assert!(*cluster_of_src <= 1.0);
+    assert!(*cluster_of_dst >= 1);
+    assert!(*cluster_of_dst <= 5);
+    assert!(*cluster_of_src >= 1);
+    assert!(*cluster_of_src <= 5);
   }
 
   //  TODO: Add asserts for specific score cluster values.
+}
+
+#[test]
+fn separate_clusters() {
+  let mut graph = AugMultiGraph::new();
+
+  graph.write_put_edge("", "U1", "U2", 2.0, -1);
+  graph.write_put_edge("", "U1", "B1", 3.0, -1);
+  graph.write_put_edge("", "U1", "C1", 4.0, -1);
+
+  let res: Vec<_> = graph.read_scores(
+    "",
+    "U1",
+    "",
+    true,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
+
+  println!("{:?}", res);
+
+  assert_eq!(res.len(), 4);
+
+  assert_eq!(res[0].4, 5);
+  assert_eq!(res[1].4, 5);
+  assert_eq!(res[2].4, 5);
+  assert_eq!(res[3].4, 5);
 }

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -2349,10 +2349,54 @@ fn mutual_scores_clustering() {
 }
 
 #[test]
-fn separate_clusters() {
+fn five_scores_clustering() {
   let mut graph = AugMultiGraph::new();
 
-  graph.write_put_edge("", "U1", "U2", 2.0, -1);
+  graph.write_put_edge("", "U1", "U2", 5.0, -1);
+  graph.write_put_edge("", "U1", "U3", 1.0, -1);
+  graph.write_put_edge("", "U1", "U4", 2.0, -1);
+  graph.write_put_edge("", "U1", "U5", 3.0, -1);
+  graph.write_put_edge("", "U2", "U1", 4.0, -1);
+
+  //  We will get 5 score values including self-score.
+
+  let res: Vec<_> = graph.read_scores(
+    "",
+    "U1",
+    "",
+    true,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
+
+  println!("{:?}", res);
+
+  assert_eq!(res.len(), 5);
+
+  assert!(res[0].4 <= 5);
+  assert!(res[0].4 >= 3);
+  
+  assert!(res[1].4 <= 5);
+  assert!(res[1].4 >= 2);
+
+  assert!(res[2].4 <= 5);
+  assert!(res[2].4 >= 1);
+
+  assert!(res[3].4 <= 4);
+  assert!(res[3].4 >= 1);
+
+  assert!(res[4].4 <= 3);
+  assert!(res[4].4 >= 1);
+}
+
+#[test]
+fn separate_clusters_without_users() {
+  let mut graph = AugMultiGraph::new();
+
   graph.write_put_edge("", "U1", "B1", 3.0, -1);
   graph.write_put_edge("", "U1", "C1", 4.0, -1);
 
@@ -2371,10 +2415,38 @@ fn separate_clusters() {
 
   println!("{:?}", res);
 
-  assert_eq!(res.len(), 4);
+  assert_eq!(res.len(), 3);
 
   assert_eq!(res[0].4, 5);
   assert_eq!(res[1].4, 5);
   assert_eq!(res[2].4, 5);
-  assert_eq!(res[3].4, 5);
+}
+
+#[test]
+fn separate_clusters_self_score() {
+  let mut graph = AugMultiGraph::new();
+
+  graph.write_put_edge("", "U1", "U2", 2.0, -1);
+  graph.write_put_edge("", "U1", "B1", 3.0, -1);
+  graph.write_put_edge("", "U1", "C1", 4.0, -1);
+
+  let res: Vec<_> = graph.read_scores(
+    "",
+    "U1",
+    "U",
+    true,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
+
+  println!("{:?}", res);
+
+  assert_eq!(res.len(), 2);
+
+  assert_eq!(res[0].4, 5);
+  assert_eq!(res[1].4, 1);
 }


### PR DESCRIPTION
- [x] In unnamed context, `read_scores` proc will return merged data from both zero opinion layer and MeritRank.
- [x] Fix ranks updates after changes.
- [x] Separate clusters for users, beacons and comments.
- [x] Return score clusters as integer values, 0 for no cluster.
- [x] Fix cluster bounds bug.