### PR TITLE
Refac read_graph

### DIFF
--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meritrank_service"
-version = "0.2.41"
+version = "0.2.42"
 edition = "2021"
 
 [features]

--- a/service/src/aug_multi_graph.rs
+++ b/service/src/aug_multi_graph.rs
@@ -128,6 +128,13 @@ impl AugMultiGraph {
     self.node_ids.get(node_name).is_some()
   }
 
+  pub fn get_subgraph_from_context(
+    &mut self,
+    context: &str,
+  )-> &Subgraph {
+    &*self.subgraph_from_context(context)
+  }
+
   pub fn subgraph_from_context(
     &mut self,
     context: &str,

--- a/service/src/operations.rs
+++ b/service/src/operations.rs
@@ -4,7 +4,7 @@
 //
 //  ================================================
 
-use meritrank_core::{constants::EPSILON, NodeId};
+use meritrank_core::{constants::EPSILON, Graph, NodeId};
 use petgraph::{
   graph::{DiGraph, NodeIndex},
   visit::EdgeRef,
@@ -17,6 +17,7 @@ use crate::bloom_filter::*;
 use crate::constants::*;
 use crate::log::*;
 use crate::nodes::*;
+use crate::subgraph::Subgraph;
 
 pub fn read_version() -> &'static str {
   log_command!();
@@ -455,6 +456,7 @@ impl AugMultiGraph {
     }
   }
 
+
   pub fn read_graph(
     &mut self,
     context: &str,
@@ -511,15 +513,11 @@ impl AugMultiGraph {
       ids.insert(index, focus_id);
     }
 
-    // Get configuration parameters
-    let num_walks = self.settings.num_walks;
-    let zero_opinion_factor = self.settings.zero_opinion_factor;
-
     // Clone node information for use in the function
     let node_infos = self.node_infos.clone();
 
     // Get the subgraph for the specified context
-    let subgraph = self.subgraph_from_context(context);
+    let subgraph = self.get_subgraph_from_context(context);
 
     log_verbose!("Enumerate focus neighbors");
 
@@ -527,39 +525,30 @@ impl AugMultiGraph {
     // This gives us all nodes directly connected to the focus node
     let focus_neighbors = subgraph.all_outbound_neighbors_normalized(focus_id);
 
+    // Handle the case where ego and focus are the same node
+    if ego_id == focus_id {
+      log_verbose!("Ego is same as focus");
+    } else {
+      // Find the shortest path from ego to focus and add it to the graph
+      add_shortest_path_to_graph(
+        &subgraph,
+        &node_infos,
+        ego_id, focus_id, &mut indices, &mut ids, &mut im_graph);
+    }
+
     // Process each neighbor of the focus node
     for (dst_id, focus_dst_weight) in focus_neighbors {
       let dst_kind = node_kind_from_id(&node_infos, dst_id);
+      // Skip if positive_only is true and the is not positive
+      if positive_only && focus_dst_weight <= 0.0
+      {
+        continue;
+      }
 
       // If the neighbor is a User node, add it directly to the graph
       if dst_kind == NodeKind::User {
-        // Skip if positive_only is true and the score is not positive
-        if positive_only
-          && subgraph.fetch_raw_score(
-          ego_id,
-          dst_id,
-          num_walks,
-          zero_opinion_factor,
-        ) <= 0.0
-        {
-          continue;
-        }
-
-        // Add the node to the graph if it doesn't exist yet
-        if !indices.contains_key(&dst_id) {
-          let index = im_graph.add_node(focus_id);
-          indices.insert(dst_id, index);
-          ids.insert(index, dst_id);
-        }
-
-        // Add an edge from focus to this user
-        if let (Some(focus_idx), Some(dst_idx)) =
-          (indices.get(&focus_id), indices.get(&dst_id))
-        {
-          im_graph.add_edge(*focus_idx, *dst_idx, focus_dst_weight);
-        } else {
-          log_error!("Got invalid node id");
-        }
+        // Inside the loop where the edge is being added
+        add_edge_if_valid(&mut im_graph, &mut indices, &mut ids, focus_id, dst_id, focus_dst_weight);
       }
       // If the neighbor is a Comment, Beacon, or Opinion node, process its neighbors
       // This handles indirect connections through non-user nodes
@@ -590,115 +579,8 @@ impl AugMultiGraph {
             1.0
           };
 
-          // Add the node to the graph if it doesn't exist yet
-          if !indices.contains_key(&ngh_id) {
-            let index = im_graph.add_node(ngh_id);
-            indices.insert(ngh_id, index);
-            ids.insert(index, ngh_id);
-          }
-
           // Add an edge from focus to this neighbor
-          if let (Some(focus_idx), Some(ngh_idx)) =
-            (indices.get(&focus_id), indices.get(&ngh_id))
-          {
-            im_graph.add_edge(*focus_idx, *ngh_idx, focus_ngh_weight);
-          } else {
-            log_error!("Got invalid node id");
-          }
-        }
-      }
-    }
-
-    // Handle the case where ego and focus are the same node
-    if ego_id == focus_id {
-      log_verbose!("Ego is same as focus");
-    } else {
-      // Find the shortest path from ego to focus using A* search
-      log_verbose!("Search shortest path");
-
-      let graph_cloned = subgraph.meritrank_data.graph.clone();
-
-      // Perform A* search to find the path from ego to focus
-      // This helps establish a connection between the ego and focus nodes
-      let ego_to_focus = match perform_astar_search(&graph_cloned, ego_id, focus_id) {
-        Ok(path) => path,
-        Err(error) => {
-          log_error!("{}", error);
-          return vec![];
-        }
-      };
-
-      // Process the path found by A* search
-      let mut edges = Vec::<(NodeId, NodeId, Weight)>::new();
-      edges.reserve_exact(ego_to_focus.len() - 1);
-
-      log_verbose!("Process shortest path");
-
-      // Process each edge in the path
-      for k in 0..ego_to_focus.len() - 1 {
-        let a = ego_to_focus[k];
-        let b = ego_to_focus[k + 1];
-
-        let a_kind = node_kind_from_id(&node_infos, a);
-        let b_kind = node_kind_from_id(&node_infos, b);
-
-        let a_b_weight = subgraph.edge_weight_normalized(a, b);
-
-        // Handle different cases based on node types and position in the path
-        // This logic determines which edges to include in the final graph
-        if k + 2 == ego_to_focus.len() {
-          // Last edge in the path
-          if a_kind == NodeKind::User {
-            edges.push((a, b, a_b_weight));
-          } else {
-            log_verbose!("Ignore node {}", node_name_from_id(&node_infos, a));
-          }
-        } else if b_kind != NodeKind::User {
-          // Skip non-user nodes in the middle of the path
-          // Create a direct edge from a to c (skipping b)
-          log_verbose!("Ignore node {}", node_name_from_id(&node_infos, b));
-          let c = ego_to_focus[k + 2];
-          let b_c_weight = subgraph.edge_weight_normalized(b, c);
-          let a_c_weight = a_b_weight
-            * b_c_weight
-            * if a_b_weight < 0.0 && b_c_weight < 0.0 {
-            -1.0
-          } else {
-            1.0
-          };
-          edges.push((a, c, a_c_weight));
-        } else if a_kind == NodeKind::User {
-          // Include edges between user nodes
-          edges.push((a, b, a_b_weight));
-        } else {
-          log_verbose!("Ignore node {}", node_name_from_id(&node_infos, a));
-        }
-      }
-
-      log_verbose!("Add path to the graph");
-
-      // Add all edges from the path to the graph
-      for (src, dst, weight) in edges {
-        // Add nodes if they don't exist yet
-        if !indices.contains_key(&src) {
-          let index = im_graph.add_node(src);
-          indices.insert(src, index);
-          ids.insert(index, src);
-        }
-
-        if !indices.contains_key(&dst) {
-          let index = im_graph.add_node(dst);
-          indices.insert(dst, index);
-          ids.insert(index, dst);
-        }
-
-        // Add the edge to the graph
-        if let (Some(src_idx), Some(dst_idx)) =
-          (indices.get(&src), indices.get(&dst))
-        {
-          im_graph.add_edge(*src_idx, *dst_idx, weight);
-        } else {
-          log_error!("Got invalid node id");
+          add_edge_if_valid(&mut im_graph, &mut indices, &mut ids, focus_id, ngh_id, focus_ngh_weight);
         }
       }
     }
@@ -1138,7 +1020,7 @@ impl AugMultiGraph {
   }
 }
 fn perform_astar_search(
-  graph_cloned: &meritrank_core::graph::Graph,
+  graph: &Graph,
   ego_id: NodeId,
   focus_id: NodeId,
 ) -> Result<Vec<NodeId>, String> {
@@ -1169,7 +1051,7 @@ fn perform_astar_search(
 
     match status.clone() {
       Status::NEIGHBOR(request) => {
-        match graph_cloned.get_node_data(request.node) {
+        match graph.get_node_data(request.node) {
           None => neighbor = None,
           Some(data) => {
             let kv: Vec<_> =
@@ -1227,5 +1109,115 @@ fn perform_astar_search(
     Err(format!("Path does not exist from {} to {}", ego_id, focus_id))
   } else {
     Err(format!("Unable to find a path from {} to {}", ego_id, focus_id))
+  }
+}
+// Helper method to find the shortest path from ego to focus and add it to the graph
+fn add_shortest_path_to_graph(
+  subgraph: &Subgraph,
+  node_infos:  &Vec<NodeInfo>,
+  ego_id: NodeId,
+  focus_id: NodeId,
+  indices: &mut HashMap<NodeId, NodeIndex>,
+  ids: &mut HashMap<NodeIndex, NodeId>,
+  im_graph: &mut DiGraph<NodeId, Weight>,
+) {
+  // Find the shortest path from ego to focus using A* search
+  log_verbose!("Search shortest path");
+  let graph = &subgraph.meritrank_data.graph;
+
+  // Perform A* search to find the path from ego to focus
+  // This helps establish a connection between the ego and focus nodes
+  let ego_to_focus = match perform_astar_search(&graph, ego_id, focus_id) {
+    Ok(path) => path,
+    Err(error) => {
+      log_error!("{}", error);
+      return;
+    }
+  };
+
+  // Process the path found by A* search
+  let mut edges = Vec::<(NodeId, NodeId, Weight)>::new();
+  edges.reserve_exact(ego_to_focus.len() - 1);
+
+  log_verbose!("Process shortest path");
+
+  // Process each edge in the path
+  for k in 0..ego_to_focus.len() - 1 {
+    let a = ego_to_focus[k];
+    let b = ego_to_focus[k + 1];
+
+    let a_kind = node_kind_from_id(node_infos, a);
+    let b_kind = node_kind_from_id(node_infos, b);
+
+    let a_b_weight = subgraph.edge_weight_normalized(a, b);
+
+    // Handle different cases based on node types and position in the path
+    // This logic determines which edges to include in the final graph
+    if k + 2 == ego_to_focus.len() {
+      // Last edge in the path
+      if a_kind == NodeKind::User {
+        edges.push((a, b, a_b_weight));
+      } else {
+        log_verbose!("Ignore node {}", node_name_from_id(node_infos, a));
+      }
+    } else if b_kind != NodeKind::User {
+      // Skip non-user nodes in the middle of the path
+      // Create a direct edge from a to c (skipping b)
+      log_verbose!("Ignore node {}", node_name_from_id(node_infos, b));
+      let c = ego_to_focus[k + 2];
+      let b_c_weight = subgraph.edge_weight_normalized(b, c);
+      let a_c_weight = a_b_weight
+        * b_c_weight
+        * if a_b_weight < 0.0 && b_c_weight < 0.0 {
+        -1.0
+      } else {
+        1.0
+      };
+      edges.push((a, c, a_c_weight));
+    } else if a_kind == NodeKind::User {
+      // Include edges between user nodes
+      edges.push((a, b, a_b_weight));
+    } else {
+      log_verbose!("Ignore node {}", node_name_from_id(node_infos, a));
+    }
+  }
+
+  log_verbose!("Add path to the graph");
+
+  // Add all edges from the path to the graph
+  for (src, dst, weight) in edges {
+    // Add nodes if they don't exist yet
+    if !indices.contains_key(&src) {
+      let index = im_graph.add_node(src);
+      indices.insert(src, index);
+      ids.insert(index, src);
+    }
+
+    // Add the edge to the graph
+    add_edge_if_valid(im_graph, indices, ids, src, dst, weight);
+  }
+}
+
+
+fn add_edge_if_valid(
+  im_graph: &mut DiGraph<NodeId, Weight>,
+  indices: &mut HashMap<NodeId, NodeIndex>,
+  ids: &mut HashMap<NodeIndex, NodeId>,
+  focus_id: NodeId,
+  dst_id: NodeId,
+  focus_dst_weight: Weight,
+) {
+  // Add the node to the graph if it doesn't exist yet
+  if !indices.contains_key(&dst_id) {
+    let index = im_graph.add_node(focus_id);
+    indices.insert(dst_id, index);
+    ids.insert(index, dst_id);
+  }
+  if let (Some(focus_idx), Some(dst_idx)) =
+    (indices.get(&focus_id), indices.get(&dst_id))
+  {
+    im_graph.add_edge(*focus_idx, *dst_idx, focus_dst_weight);
+  } else {
+    log_error!("Got invalid node id");
   }
 }

--- a/service/src/subgraph.rs
+++ b/service/src/subgraph.rs
@@ -82,7 +82,7 @@ impl Subgraph {
   }
 
   pub fn edge_weight_normalized(
-    &mut self,
+    &self,
     src: NodeId,
     dst: NodeId,
   ) -> Weight {
@@ -113,7 +113,7 @@ impl Subgraph {
   }
 
   pub fn all_outbound_neighbors_normalized(
-    &mut self,
+    &self,
     node: NodeId,
   ) -> Vec<(NodeId, Weight)> {
     log_trace!("{}", node);

--- a/service/src/subgraph.rs
+++ b/service/src/subgraph.rs
@@ -125,25 +125,24 @@ impl Subgraph {
       Some(data) => {
         v.reserve_exact(data.pos_edges.len() + data.neg_edges.len());
 
-        let pos_sum = if data.pos_sum < EPSILON {
+        let abs_sum = if data.pos_sum < EPSILON {
           log_warning!(
             "Unable to normalize node weight, positive sum is zero."
           );
           1.0
         } else {
-          data.pos_sum
+          data.abs_sum()
         };
 
         for x in &data.pos_edges {
-          v.push((*x.0, *x.1 / pos_sum));
+          v.push((*x.0, *x.1 / abs_sum));
         }
 
         for x in &data.neg_edges {
-          v.push((*x.0, *x.1 / pos_sum));
+          v.push((*x.0, -*x.1 / abs_sum));
         }
       },
     }
-
     v
   }
 

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -1214,24 +1214,26 @@ fn graph_empty() {
 }
 
 #[test]
-fn graph_removed_edge() {
+#[test]
+fn graph_no_direct_connectivity() {
+  // Test that graph will show the focus and its neighborhood
+  // even if there is no true path from ego to focus.
+  // (E.g. when focusing directly by id or through zero opinion)
   let mut graph = default_graph();
 
-  graph.write_put_edge("", "U1", "B2", 1.0, -1);
-  graph.write_put_edge("", "B2", "U1", 2.0, -1);
-  graph.write_put_edge("", "B2", "C2", 1.0, -1);
-  graph.write_put_edge("", "B2", "C3", 1.5, -1);
-  graph.write_put_edge("", "B2", "C4", 3.0, -1);
+  graph.write_put_edge("", "U1", "B1", 1.0, -1);
+  graph.write_put_edge("", "U2", "U3", 1.0, -1);
+  graph.write_put_edge("", "U2", "B2", 1.0, -1);
 
-  graph.write_delete_edge("", "U1", "B2", -1);
-
-  let res: Vec<_> = graph.read_graph("", "U1", "B2", false, 0, 10000);
+  let res: Vec<_> = graph.read_graph("", "U1", "U2", false, 0, 10000);
 
   for x in res.iter() {
     println!("{} -> {}: {}", x.0, x.1, x.2);
   }
 
-  assert_eq!(res.len(), 0);
+  assert_eq!(res.len(), 1);
+  assert_eq!(res[0].0, "U2");
+  assert_eq!(res[0].1, "U3");
 }
 
 #[test]


### PR DESCRIPTION
Refacs `read_graph` for clarity and changes its behaviour:
1. show the neighbors of the focus even if there is no direct connectivity (e.g. when going through zero opinion or direct id)
2. `positive_only` arg now refers to edge weights, not scores
