### PR TITLE
Add option to filter scores of nodes with negative edges

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meritrank_core"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2021"
 description = "MeritRank algorithm library"
 license = "MIT"

--- a/core/src/rank.rs
+++ b/core/src/rank.rs
@@ -87,9 +87,10 @@ impl MeritRank {
     Ok(hits_penalized / total_hits as Weight)
   }
 
-  pub fn get_ranks(
+  pub fn get_all_scores(
     &self,
     ego: NodeId,
+    omit_negative_edges: bool,
     limit: Option<usize>,
   ) -> Result<Vec<(NodeId, Weight)>, MeritRankError> {
     let pos_counter = self
@@ -106,6 +107,16 @@ impl MeritRank {
 
     let mut peer_scores: Vec<_> = combined_counter
       .into_iter()
+      .filter(|&peer| {
+        if omit_negative_edges {
+          match self.graph.edge_weight(ego, *peer) {
+            Ok(Some(weight)) => weight > 0.0, // Keep only positive edges
+            _ => true, // Keep if no direct edge exists
+          }
+        } else {
+          true // Keep all nodes if filtering is disabled
+        }
+      })
       .map(|&peer| self.get_node_score(ego, peer).map(|score| (peer, score)))
       .collect::<Result<_, _>>()?;
 

--- a/core/tests/test_dumps.rs
+++ b/core/tests/test_dumps.rs
@@ -131,7 +131,7 @@ mod tests {
       // meritrank.calculate(2, 1000)?;
       // meritrank.calculate(3, 1000);
 
-      let rating: HashMap<NodeId, f64> = meritrank.get_ranks(0, None).unwrap_or({
+      let rating: HashMap<NodeId, f64> = meritrank.get_all_scores(0, false, None).unwrap_or({
         vec![
           (0, 0.0),
           (1, 0.0),
@@ -235,7 +235,7 @@ mod tests {
       meritrank.calculate(0, 10000)?;
 
       let rating: Vec<(NodeId, f64)> =
-        meritrank.get_ranks(0, None).unwrap_or_default();
+        meritrank.get_all_scores(0, false, None).unwrap_or_default();
 
       // check rating
       eprintln!(
@@ -330,7 +330,7 @@ mod tests {
       let rating: HashMap<NodeId, f64> = meritrank_opt
         .as_ref()
         .ok_or("MeritRank not initialized")?
-        .get_ranks(0, None)
+        .get_all_scores(0, false, None)
         .unwrap_or_default()
         .into_iter()
         .collect();
@@ -425,7 +425,7 @@ mod tests {
       let rating: Vec<(NodeId, f64)> = meritrank_opt
         .as_ref()
         .ok_or("MeritRank not initialized")?
-        .get_ranks(0, None)
+        .get_all_scores(0, false, None)
         .unwrap_or_default();
 
       let expected_ranks: [f64; 4] = [

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meritrank_service"
-version = "0.2.45"
+version = "0.2.46"
 edition = "2021"
 
 [features]

--- a/service/README.md
+++ b/service/README.md
@@ -14,3 +14,4 @@ NNG server for [PSQL Connector](/psql-connector/README.md) with embedded Rust [M
 - `MERITRANK_FILTER_NUM_HASHES` - default `10`
 - `MERITRANK_FILTER_MIN_SIZE` - default `32`
 - `MERITRANK_FILTER_MAX_SIZE` - default `8192`
+- `MERITRANK_OMIT_NEG_EDGES_SCORES` - default `false`

--- a/service/src/aug_multi_graph.rs
+++ b/service/src/aug_multi_graph.rs
@@ -31,6 +31,7 @@ pub struct AugMultiGraphSettings {
   pub filter_num_hashes:      usize,
   pub filter_max_size:        usize,
   pub filter_min_size:        usize,
+  pub omit_neg_edges_scores:  bool,
 }
 
 #[derive(Clone)]
@@ -57,6 +58,7 @@ impl Default for AugMultiGraphSettings {
       filter_max_size:        DEFAULT_FILTER_MAX_SIZE,
       filter_min_size:        DEFAULT_FILTER_MIN_SIZE,
       top_nodes_limit:        DEFAULT_TOP_NODES_LIMIT,
+      omit_neg_edges_scores:  DEFAULT_OMIT_NEG_EDGES_SCORES,
     }
   }
 }
@@ -148,6 +150,7 @@ impl AugMultiGraph {
         cached_scores:         LruCache::new(self.settings.scores_cache_size),
         cached_walks:          LruCache::new(self.settings.walks_cache_size),
         cached_score_clusters: Vec::new(),
+        omit_neg_edges_scores: self.settings.omit_neg_edges_scores,
       });
 
     // Add nodes to the zero context if needed
@@ -218,6 +221,7 @@ impl AugMultiGraph {
         cached_scores:         LruCache::new(self.settings.scores_cache_size),
         cached_walks:          LruCache::new(self.settings.walks_cache_size),
         cached_score_clusters: Vec::new(),
+        omit_neg_edges_scores: self.settings.omit_neg_edges_scores,
       },
     );
 

--- a/service/src/constants.rs
+++ b/service/src/constants.rs
@@ -19,3 +19,4 @@ pub const DEFAULT_WALKS_CACHE_SIZE: NonZeroUsize =
 pub const DEFAULT_FILTER_NUM_HASHES: usize = 10;
 pub const DEFAULT_FILTER_MAX_SIZE: usize = 8192;
 pub const DEFAULT_FILTER_MIN_SIZE: usize = 32;
+pub const DEFAULT_OMIT_NEG_EDGES_SCORES: bool = false;

--- a/service/src/service.rs
+++ b/service/src/service.rs
@@ -491,6 +491,28 @@ where
   Ok(())
 }
 
+// Add a new function to parse boolean environment variables
+fn parse_and_set_bool(
+  value: &mut bool,
+  name: &str,
+) -> Result<(), ()> {
+  match var(name) {
+    Ok(s) => {
+      if s == "1" || s.to_lowercase() == "true" || s.to_lowercase() == "yes" {
+        *value = true;
+        Ok(())
+      } else if s == "0" || s.to_lowercase() == "false" || s.to_lowercase() == "no" {
+        *value = false;
+        Ok(())
+      } else {
+        log_error!("Invalid {} (expected 0/1, true/false, yes/no): {:?}", name, s);
+        Err(())
+      }
+    },
+    _ => Ok(()),
+  }
+}
+
 pub fn parse_settings() -> Result<AugMultiGraphSettings, ()> {
   let mut settings = AugMultiGraphSettings::default();
 
@@ -568,6 +590,10 @@ pub fn parse_settings() -> Result<AugMultiGraphSettings, ()> {
     "MERITRANK_FILTER_MIN_SIZE",
     1,
     1024 * 1024 * 10,
+  )?;
+  parse_and_set_bool(
+    &mut settings.omit_neg_edges_scores,
+    "MERITRANK_OMIT_NEG_EDGES_SCORES",
   )?;
 
   Ok(settings)

--- a/service/src/service.rs
+++ b/service/src/service.rs
@@ -501,11 +501,18 @@ fn parse_and_set_bool(
       if s == "1" || s.to_lowercase() == "true" || s.to_lowercase() == "yes" {
         *value = true;
         Ok(())
-      } else if s == "0" || s.to_lowercase() == "false" || s.to_lowercase() == "no" {
+      } else if s == "0"
+        || s.to_lowercase() == "false"
+        || s.to_lowercase() == "no"
+      {
         *value = false;
         Ok(())
       } else {
-        log_error!("Invalid {} (expected 0/1, true/false, yes/no): {:?}", name, s);
+        log_error!(
+          "Invalid {} (expected 0/1, true/false, yes/no): {:?}",
+          name,
+          s
+        );
         Err(())
       }
     },

--- a/service/src/subgraph.rs
+++ b/service/src/subgraph.rs
@@ -13,6 +13,7 @@ pub struct Subgraph {
   pub cached_scores:         LruCache<(NodeId, NodeId), Weight>,
   pub cached_walks:          LruCache<NodeId, ()>,
   pub cached_score_clusters: Vec<ScoreClustersByKind>,
+  pub omit_neg_edges_scores: bool,
 }
 
 impl Subgraph {
@@ -204,7 +205,7 @@ impl Subgraph {
 
     if self.cache_walk_get(ego_id) {
       let data = &self.meritrank_data;
-      match data.get_ranks(ego_id, None) {
+      match data.get_all_scores(ego_id, self.omit_neg_edges_scores, None) {
         Ok(scores) => {
           for (dst_id, score) in &scores {
             self.cache_score_add(ego_id, *dst_id, *score);
@@ -226,7 +227,7 @@ impl Subgraph {
           return vec![];
         },
       }
-      match self.meritrank_data.get_ranks(ego_id, None) {
+      match self.meritrank_data.get_all_scores(ego_id, self.omit_neg_edges_scores, None) {
         Ok(scores) => {
           for (dst_id, score) in &scores {
             self.cache_score_add(ego_id, *dst_id, *score);

--- a/service/src/subgraph.rs
+++ b/service/src/subgraph.rs
@@ -227,7 +227,11 @@ impl Subgraph {
           return vec![];
         },
       }
-      match self.meritrank_data.get_all_scores(ego_id, self.omit_neg_edges_scores, None) {
+      match self.meritrank_data.get_all_scores(
+        ego_id,
+        self.omit_neg_edges_scores,
+        None,
+      ) {
         Ok(scores) => {
           for (dst_id, score) in &scores {
             self.cache_score_add(ego_id, *dst_id, *score);

--- a/service/src/tests.rs
+++ b/service/src/tests.rs
@@ -1905,47 +1905,50 @@ fn omit_neg_edges_scores_setting() {
   });
 
   // Add the same edges to both graphs
-    // Add the same edges to both graphs
-    let edges = vec![
-      ("U1".to_string(), "U2".to_string(), -1.0),  // Negative edge from U1 to U2
-      ("U1".to_string(), "U3".to_string(), 10.0),   // Positive edge from U1 to U3
-      ("U3".to_string(), "U2".to_string(), 1.0),   // Positive edge from U3 to U2
-    ];
+  // Add the same edges to both graphs
+  let edges = vec![
+    ("U1".to_string(), "U2".to_string(), -1.0), // Negative edge from U1 to U2
+    ("U1".to_string(), "U3".to_string(), 10.0), // Positive edge from U1 to U3
+    ("U3".to_string(), "U2".to_string(), 1.0),  // Positive edge from U3 to U2
+  ];
 
-    for (src, dst, weight) in edges {
-      graph_omit.write_put_edge("", &src, &dst, weight, -1);
-      graph_include.write_put_edge("", &src, &dst, weight, -1);
-    }
+  for (src, dst, weight) in edges {
+    graph_omit.write_put_edge("", &src, &dst, weight, -1);
+    graph_include.write_put_edge("", &src, &dst, weight, -1);
+  }
 
-    // Get scores for U1 in both graphs
-    let scores_omit = graph_omit.read_scores(
-      "",
-      "U1",
-      "U",
-      false,
-      100.0,
-      false,
-      -100.0,
-      false,
-      0,
-      u32::MAX,
-    );
+  // Get scores for U1 in both graphs
+  let scores_omit = graph_omit.read_scores(
+    "",
+    "U1",
+    "U",
+    false,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
 
-    let scores_include = graph_include.read_scores(
-      "",
-      "U1",
-      "U",
-      false,
-      100.0,
-      false,
-      -100.0,
-      false,
-      0,
-      u32::MAX,
-    );
+  let scores_include = graph_include.read_scores(
+    "",
+    "U1",
+    "U",
+    false,
+    100.0,
+    false,
+    -100.0,
+    false,
+    0,
+    u32::MAX,
+  );
 
-    // Check if U2 is present in both result sets
-    let find_node_score = |scores: &Vec<(String, String, Weight, Weight, Cluster, Cluster)>, node: &str| -> Option<Weight> {
+  // Check if U2 is present in both result sets
+  let find_node_score =
+    |scores: &Vec<(String, String, Weight, Weight, Cluster, Cluster)>,
+     node: &str|
+     -> Option<Weight> {
       for (_, n, score, _, _, _) in scores {
         if n == node {
           return Some(*score);
@@ -1958,7 +1961,12 @@ fn omit_neg_edges_scores_setting() {
   let u2_score_omit = find_node_score(&scores_omit, "U2");
 
   // U2 should have a score in the graph that includes negative edges
-  assert!(u2_score_include.is_some(), "U2 should have a score when negative edges are included");
-  assert!(u2_score_omit.is_none(), "U2 should not have a score when negative edges are omitted");
-
-  }
+  assert!(
+    u2_score_include.is_some(),
+    "U2 should have a score when negative edges are included"
+  );
+  assert!(
+    u2_score_omit.is_none(),
+    "U2 should not have a score when negative edges are omitted"
+  );
+}

--- a/service/src/zero_opinion.rs
+++ b/service/src/zero_opinion.rs
@@ -108,6 +108,7 @@ impl Subgraph {
     top_nodes_limit: usize,
     num_walks: usize,
     zero_opinion_factor: f64,
+    omit_negative_edges: bool,
   ) -> Vec<(NodeId, f64)> {
     log_trace!();
 
@@ -183,6 +184,7 @@ impl AugMultiGraph {
         self.settings.top_nodes_limit,
         self.settings.zero_opinion_num_walks,
         self.settings.zero_opinion_factor,
+        false,
       );
 
       //  Drop all walks and make sure to empty caches.


### PR DESCRIPTION
E.g. when 
(A,B,1)
(B,C,1)
(A,C,-1)

if the `MERITRANK_OMIT_NEG_EDGES_SCORES` is set to `true`, will omit C completely when A is ego, because A has at least one direct negative edge into it. 

By default the option is `false` so no change with previous behavior.