### PR TITLE
Polling feature (quickhack)

### DIFF
--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meritrank_service"
-version = "0.2.52"
+version = "0.2.53"
 edition = "2021"
 
 [features]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod errors;
 pub mod log;
+pub mod poll;
 pub mod protocol;

--- a/service/src/nodes.rs
+++ b/service/src/nodes.rs
@@ -1,6 +1,5 @@
 use crate::constants::*;
 use crate::log::*;
-// use crate::protocol::*; // Removed unused import
 use std::ops::{Index, IndexMut};
 
 pub use meritrank_core::{NodeId, Weight};
@@ -8,18 +7,22 @@ pub use meritrank_core::{NodeId, Weight};
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum NodeKind {
   #[default]
-  Unknown,
+  Unknown,  // TODO: remove this completely and instead propagate errors
   User,
   Beacon,
   Comment,
   Opinion,
+  PollOption, // alt name is "Vote"
+  Poll, 
 }
 
-pub const ALL_NODE_KINDS: [NodeKind; 4] = [
+pub const ALL_NODE_KINDS: [NodeKind; 6] = [
   NodeKind::User,
   NodeKind::Beacon,
   NodeKind::Comment,
   NodeKind::Opinion,
+  NodeKind::PollOption,
+  NodeKind::Poll,
 ];
 
 // NeighborDirection enum REMOVED from here
@@ -55,6 +58,8 @@ pub struct ScoreClustersByKind {
   pub beacons:  ClusterGroupBounds,
   pub comments: ClusterGroupBounds,
   pub opinions: ClusterGroupBounds,
+  pub poll_options:    ClusterGroupBounds, // TODO: remove
+  pub polls:    ClusterGroupBounds, // TODO: remove
 }
 
 impl Index<NodeKind> for ScoreClustersByKind {
@@ -70,6 +75,8 @@ impl Index<NodeKind> for ScoreClustersByKind {
       NodeKind::Beacon => &self.beacons,
       NodeKind::Comment => &self.comments,
       NodeKind::Opinion => &self.opinions,
+      NodeKind::PollOption => &self.poll_options, // TODO: remove
+      NodeKind::Poll => &self.polls, // TODO: remove
     }
   }
 }
@@ -85,6 +92,8 @@ impl IndexMut<NodeKind> for ScoreClustersByKind {
       NodeKind::Beacon => &mut self.beacons,
       NodeKind::Comment => &mut self.comments,
       NodeKind::Opinion => &mut self.opinions,
+      NodeKind::PollOption => &mut self.poll_options, // New case
+      NodeKind::Poll => &mut self.polls, // New case
     }
   }
 }
@@ -97,6 +106,8 @@ pub fn kind_from_name(name: &str) -> NodeKind {
     Some('B') => NodeKind::Beacon,
     Some('C') => NodeKind::Comment,
     Some('O') => NodeKind::Opinion,
+    Some('V') => NodeKind::PollOption,
+    Some('P') => NodeKind::Poll,
     _ => NodeKind::Unknown,
   }
 }
@@ -108,11 +119,11 @@ pub fn kind_from_prefix(prefix: &str) -> Result<NodeKind, ()> {
     "B" => Ok(NodeKind::Beacon),
     "C" => Ok(NodeKind::Comment),
     "O" => Ok(NodeKind::Opinion),
+    "V" => Ok(NodeKind::PollOption), // "V" stands for "Vote"
+    "P" => Ok(NodeKind::Poll),
     _ => Err(()),
   }
 }
-
-// neighbor_dir_from function REMOVED from here
 
 pub fn node_name_from_id(
   infos: &[NodeInfo],

--- a/service/src/poll.rs
+++ b/service/src/poll.rs
@@ -1,0 +1,155 @@
+use meritrank_core::{NodeId, Weight};
+use std::collections::{HashMap, HashSet};
+
+pub type PollId = NodeId;
+pub type PollOptionId = NodeId;
+pub type UserId = NodeId;
+
+#[derive(Debug, Clone)]
+struct Vote {
+  option: PollOptionId,
+  weight: Weight,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PollStore {
+  polls:   HashMap<PollId, HashSet<PollOptionId>>,
+  options: HashMap<PollOptionId, PollId>,
+  votes:   HashMap<PollId, HashMap<UserId, Vote>>,
+}
+
+impl PollStore {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub fn add_poll_option(
+    &mut self,
+    option: PollOptionId,
+    poll: PollId,
+  ) -> Result<(), &'static str> {
+    if self.options.contains_key(&option) {
+      return Err("Option already exists in a poll");
+    }
+
+    self.polls.entry(poll).or_default().insert(option);
+    self.options.insert(option, poll);
+    Ok(())
+  }
+
+  pub fn add_user_vote(
+    &mut self,
+    user: UserId,
+    option: PollOptionId,
+    weight: Weight,
+  ) -> Result<(), &'static str> {
+    let poll = self.options.get(&option).ok_or("Option does not exist")?;
+    let vote = Vote {
+      option,
+      weight,
+    };
+    self.votes.entry(*poll).or_default().insert(user, vote);
+    Ok(())
+  }
+
+  pub fn remove_option_from_poll(
+    &mut self,
+    option: PollOptionId,
+  ) -> Result<(), &'static str> {
+    let poll = self
+      .options
+      .remove(&option)
+      .ok_or("Option does not exist")?;
+    self.polls.get_mut(&poll).unwrap().remove(&option);
+
+    if let Some(poll_votes) = self.votes.get_mut(&poll) {
+      poll_votes.retain(|_, vote| vote.option != option);
+    }
+
+    Ok(())
+  }
+
+  pub fn remove_user_vote(
+    &mut self,
+    user: UserId,
+    poll: PollId,
+  ) -> Result<(), &'static str> {
+    if let Some(poll_votes) = self.votes.get_mut(&poll) {
+      if poll_votes.remove(&user).is_none() {
+        return Err("Vote not found");
+      }
+    } else {
+      return Err("No votes for this poll");
+    }
+
+    Ok(())
+  }
+
+  pub fn remove_poll(
+    &mut self,
+    poll: PollId,
+  ) -> Result<(), &'static str> {
+    if let Some(options) = self.polls.remove(&poll) {
+      for option in options {
+        self.options.remove(&option);
+      }
+      self.votes.remove(&poll);
+      Ok(())
+    } else {
+      Err("Poll does not exist")
+    }
+  }
+
+  pub fn get_poll_options(
+    &self,
+    poll: PollId,
+  ) -> Option<&HashSet<PollOptionId>> {
+    self.polls.get(&poll)
+  }
+
+  pub fn get_option_poll(
+    &self,
+    option: PollOptionId,
+  ) -> Option<&PollId> {
+    self.options.get(&option)
+  }
+
+  fn get_poll_votes(
+    &self,
+    poll: PollId,
+  ) -> Option<&HashMap<UserId, Vote>> {
+    self.votes.get(&poll)
+  }
+
+  fn get_option_votes(
+    &self,
+    option: PollOptionId,
+  ) -> Option<Vec<(&UserId, &Vote)>> {
+    self.options.get(&option).and_then(|poll| {
+      self.votes.get(poll).map(|votes| {
+        votes
+          .iter()
+          .filter(|(_, vote)| vote.option == option)
+          .collect()
+      })
+    })
+  }
+
+  pub fn get_poll_results(
+    &self,
+    ego: UserId,
+    poll: PollId,
+  ) -> Option<Vec<(PollOptionId, Weight)>> {
+    self.votes.get(&poll).map(|poll_votes| {
+        let mut results: HashMap<PollOptionId, Weight> = HashMap::new();
+
+        for (user, vote) in poll_votes.iter() {
+          *results.entry(vote.option).or_insert(0.0) += vote.weight;
+        }
+
+        let mut sorted_results: Vec<(PollOptionId, Weight)> = results.into_iter().collect();
+        sorted_results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        sorted_results
+    })
+  }
+}

--- a/service/src/subgraph.rs
+++ b/service/src/subgraph.rs
@@ -5,6 +5,7 @@ use crate::constants::*;
 use crate::log::*;
 use crate::nodes::*;
 use crate::quantiles::*;
+use meritrank_service::poll::PollStore;
 
 #[derive(Clone)]
 pub struct Subgraph {
@@ -14,6 +15,7 @@ pub struct Subgraph {
   pub cached_walks:          LruCache<NodeId, ()>,
   pub cached_score_clusters: Vec<ScoreClustersByKind>,
   pub omit_neg_edges_scores: bool,
+  pub poll_store: PollStore,
 }
 
 impl Subgraph {


### PR DESCRIPTION
Adds polling feature:
to speed up development and keep compatibility with previous versions of FDW plugin, pushing polls options is done through `write_edge` handle, and retrieving the poll results through `read_neighbors` handle.
This PR adds only very basic polling method (just linear weights). Upcoming PRs will add more sophisticated methods based on MeritRank